### PR TITLE
CRT Royale NTSC presets

### DIFF
--- a/crt/crt-royale-ntsc-256px-composite.cgp
+++ b/crt/crt-royale-ntsc-256px-composite.cgp
@@ -1,0 +1,224 @@
+# IMPORTANT:
+# Shader passes need to know details about the image in the mask_texture LUT
+# files, so set the following constants in user-cgp-constants.h accordingly:
+# 1.) mask_triads_per_tile = (number of horizontal triads in mask texture LUT's)
+# 2.) mask_texture_small_size = (texture size of mask*texture_small LUT's)
+# 3.) mask_texture_large_size = (texture size of mask*texture_large LUT's)
+# 4.) mask_grille_avg_color = (avg. brightness of mask_grille_texture* LUT's, in [0, 1])
+# 5.) mask_slot_avg_color = (avg. brightness of mask_slot_texture* LUT's, in [0, 1])
+# 6.) mask_shadow_avg_color = (avg. brightness of mask_shadow_texture* LUT's, in [0, 1])
+# Shader passes also need to know certain scales set in this .cgp, but their
+# compilation model doesn't currently allow the .cgp file to tell them.  Make
+# sure to set the following constants in user-cgp-constants.h accordingly too:
+# 1.) bloom_approx_scale_x = scale_x2
+# 2.) mask_resize_viewport_scale = float2(scale_x6, scale_y5)
+# Finally, shader passes need to know the value of geom_max_aspect_ratio used to
+# calculate scale_y5 (among other values):
+# 1.) geom_max_aspect_ratio = (geom_max_aspect_ratio used to calculate scale_y5)
+
+shaders = "14"
+
+# NTSC Shader Passes
+shader0 = "../ntsc/shaders/ntsc-pass1-composite-3phase.cg"
+shader1 = "../ntsc/shaders/ntsc-pass2-3phase.cg"
+
+filter_linear0 = false
+filter_linear1 = false
+
+scale_type_x0 = absolute
+scale_type_y0 = source
+scale_x0 = 1024
+scale_y0 = 1.0
+frame_count_mod0 = 2
+float_framebuffer0 = true
+
+scale_type1 = source
+scale_x1 = 0.5
+scale_y1 = 1.0
+
+# Set an identifier, filename, and sampling traits for the phosphor mask texture.
+# Load an aperture grille, slot mask, and an EDP shadow mask, and load a small
+# non-mipmapped version and a large mipmapped version.
+# TODO: Test masks in other directories.
+textures = "mask_grille_texture_small;mask_grille_texture_large;mask_slot_texture_small;mask_slot_texture_large;mask_shadow_texture_small;mask_shadow_texture_large"
+mask_grille_texture_small = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5SpacingResizeTo64.png"
+mask_grille_texture_large = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5Spacing.png"
+mask_slot_texture_small = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacingResizeTo64.png"
+mask_slot_texture_large = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacing.png"
+mask_shadow_texture_small = "shaders/crt-royale/TileableLinearShadowMaskEDPResizeTo64.png"
+mask_shadow_texture_large = "shaders/crt-royale/TileableLinearShadowMaskEDP.png"
+mask_grille_texture_small_wrap_mode = "repeat"
+mask_grille_texture_large_wrap_mode = "repeat"
+mask_slot_texture_small_wrap_mode = "repeat"
+mask_slot_texture_large_wrap_mode = "repeat"
+mask_shadow_texture_small_wrap_mode = "repeat"
+mask_shadow_texture_large_wrap_mode = "repeat"
+mask_grille_texture_small_linear = "true"
+mask_grille_texture_large_linear = "true"
+mask_slot_texture_small_linear = "true"
+mask_slot_texture_large_linear = "true"
+mask_shadow_texture_small_linear = "true"
+mask_shadow_texture_large_linear = "true"
+mask_grille_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_grille_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+mask_slot_texture_small_mipmap = "false"    # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_slot_texture_large_mipmap = "true"     # Essential for hardware-resized masks
+mask_shadow_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_shadow_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+
+
+# Pass2: Linearize the input based on CRT gamma and bob interlaced fields.
+# (Bobbing ensures we can immediately blur without getting artifacts.)
+shader2 = "shaders/crt-royale/src/crt-royale-first-pass-linearize-crt-gamma-bob-fields.cg"
+alias2 = "ORIG_LINEARIZED"
+filter_linear2 = "false"
+scale_type2 = "source"
+scale2 = "1.0"
+srgb_framebuffer2 = "true"
+
+# Pass3: Resample interlaced (and misconverged) scanlines vertically.
+# Separating vertical/horizontal scanline sampling is faster: It lets us
+# consider more scanlines while calculating weights for fewer pixels, and
+# it reduces our samples from vertical*horizontal to vertical+horizontal.
+# This has to come right after ORIG_LINEARIZED, because there's no
+# "original_source" scale_type we can use later.
+shader3 = "shaders/crt-royale/src/crt-royale-scanlines-vertical-interlacing.cg"
+alias3 = "VERTICAL_SCANLINES"
+filter_linear3 = "true"
+scale_type_x3 = "source"
+scale_x3 = "1.0"
+scale_type_y3 = "viewport"
+scale_y3 = "1.0"
+#float_framebuffer3 = "true"
+srgb_framebuffer3 = "true"
+
+# Pass4: Do a small resize blur of ORIG_LINEARIZED at an absolute size, and
+# account for convergence offsets.  We want to blur a predictable portion of the
+# screen to match the phosphor bloom, and absolute scale works best for
+# reliable results with a fixed-size bloom.  Picking a scale is tricky:
+# a.) 400x300 is a good compromise for the "fake-bloom" version: It's low enough
+#     to blur high-res/interlaced sources but high enough that resampling
+#     doesn't smear low-res sources too much.
+# b.) 320x240 works well for the "real bloom" version: It's 1-1.5% faster, and
+#     the only noticeable visual difference is a larger halation spread (which
+#     may be a good thing for people who like to crank it up).
+# Note the 4:3 aspect ratio assumes the input has cropped geom_overscan (so it's
+# *intended* for an ~4:3 aspect ratio).
+shader4 = "shaders/crt-royale/src/crt-royale-bloom-approx.cg"
+alias4 = "BLOOM_APPROX"
+filter_linear4 = "true"
+scale_type4 = "absolute"
+scale_x4 = "320"
+scale_y4 = "240"
+srgb_framebuffer4 = "true"
+
+# Pass5: Vertically blur the input for halation and refractive diffusion.
+# Base this on BLOOM_APPROX: This blur should be small and fast, and blurring
+# a constant portion of the screen is probably physically correct if the
+# viewport resolution is proportional to the simulated CRT size.
+shader5 = "../blurs/blur9fast-vertical.cg"
+filter_linear5 = "true"
+scale_type5 = "source"
+scale5 = "1.0"
+srgb_framebuffer5 = "true"
+
+# Pass6: Horizontally blur the input for halation and refractive diffusion.
+# Note: Using a one-pass 9x9 blur is about 1% slower.
+shader6 = "../blurs/blur9fast-horizontal.cg"
+alias6 = "HALATION_BLUR"
+filter_linear6 = "true"
+scale_type6 = "source"
+scale6 = "1.0"
+srgb_framebuffer6 = "true"
+
+# Pass7: Lanczos-resize the phosphor mask vertically.  Set the absolute
+# scale_x7 == mask_texture_small_size.x (see IMPORTANT above).  Larger scales
+# will blur, and smaller scales could get nasty.  The vertical size must be
+# based on the viewport size and calculated carefully to avoid artifacts later.
+# First calculate the minimum number of mask tiles we need to draw.
+# Since curvature is computed after the scanline masking pass:
+#   num_resized_mask_tiles = 2.0;
+# If curvature were computed in the scanline masking pass (it's not):
+#   max_mask_texel_border = ~3.0 * (1/3.0 + 4.0*sqrt(2.0) + 0.5 + 1.0);
+#   max_mask_tile_border = max_mask_texel_border/
+#       (min_resized_phosphor_triad_size * mask_triads_per_tile);
+#   num_resized_mask_tiles = max(2.0, 1.0 + max_mask_tile_border * 2.0);
+#   At typical values (triad_size >= 2.0, mask_triads_per_tile == 8):
+#       num_resized_mask_tiles = ~3.8
+# Triad sizes are given in horizontal terms, so we need geom_max_aspect_ratio
+# to relate them to vertical resolution.  The widest we expect is:
+#   geom_max_aspect_ratio = 4.0/3.0  # Note: Shader passes need to know this!
+# The fewer triads we tile across the screen, the larger each triad will be as a
+# fraction of the viewport size, and the larger scale_y5 must be to draw a full
+# num_resized_mask_tiles.  Therefore, we must decide the smallest number of
+# triads we'll guarantee can be displayed on screen.  We'll set this according
+# to 3-pixel triads at 768p resolution (the lowest anyone's likely to use):
+#   min_allowed_viewport_triads = 768.0*geom_max_aspect_ratio / 3.0 = 341.333333
+# Now calculate the viewport scale that ensures we can draw resized_mask_tiles:
+#   min_scale_x = resized_mask_tiles * mask_triads_per_tile /
+#       min_allowed_viewport_triads
+#   scale_y7 = geom_max_aspect_ratio * min_scale_x
+#   # Some code might depend on equal scales:
+#   scale_x8 = scale_y7
+# Given our default geom_max_aspect_ratio and min_allowed_viewport_triads:
+#   scale_y7 = 4.0/3.0 * 2.0/(341.33333 / 8.0) = 0.0625
+# IMPORTANT: The scales MUST be calculated in this way.  If you wish to change
+# geom_max_aspect_ratio, update that constant in user-cgp-constants.h!
+shader7 = "shaders/crt-royale/src/crt-royale-mask-resize-vertical.cg"
+filter_linear7 = "true"
+scale_type_x7 = "absolute"
+scale_x7 = "64"
+scale_type_y7 = "viewport"
+scale_y7 = "0.0625" # Safe for >= 341.333 horizontal triads at viewport size
+#srgb_framebuffer7 = "false" # mask_texture is already assumed linear
+
+# Pass8: Lanczos-resize the phosphor mask horizontally.  scale_x8 = scale_y7.
+# TODO: Check again if the shaders actually require equal scales.
+shader8 = "shaders/crt-royale/src/crt-royale-mask-resize-horizontal.cg"
+alias8 = "MASK_RESIZE"
+filter_linear8 = "false"
+scale_type_x8 = "viewport"
+scale_x8 = "0.0625"
+scale_type_y8 = "source"
+scale_y8 = "1.0"
+#srgb_framebuffer8 = "false" # mask_texture is already assumed linear
+
+# Pass9: Resample (misconverged) scanlines horizontally, apply halation, and
+# apply the phosphor mask.
+shader9 = "shaders/crt-royale/src/crt-royale-scanlines-horizontal-apply-mask.cg"
+alias9 = "MASKED_SCANLINES"
+filter_linear9 = "true" # This could just as easily be nearest neighbor.
+scale_type9 = "viewport"
+scale9 = "1.0"
+#float_framebuffer9 = "true"
+srgb_framebuffer9 = "true"
+
+# Pass 10: Compute a brightpass.  This will require reading the final mask.
+shader10 = "shaders/crt-royale/src/crt-royale-brightpass.cg"
+alias10 = "BRIGHTPASS"
+filter_linear10 = "true" # This could just as easily be nearest neighbor.
+scale_type10 = "viewport"
+scale10 = "1.0"
+srgb_framebuffer10 = "true"
+
+# Pass 11: Blur the brightpass vertically
+shader11 = "shaders/crt-royale/src/crt-royale-bloom-vertical.cg"
+filter_linear11 = "true" # This could just as easily be nearest neighbor.
+scale_type11 = "source"
+scale11 = "1.0"
+srgb_framebuffer11 = "true"
+
+# Pass 12: Blur the brightpass horizontally and combine it with the dimpass:
+shader12 = "shaders/crt-royale/src/crt-royale-bloom-horizontal-reconstitute.cg"
+filter_linear12 = "true"
+scale_type12 = "source"
+scale12 = "1.0"
+srgb_framebuffer12 = "true"
+
+# Pass 13: Compute curvature/AA:
+shader13 = "shaders/crt-royale/src/crt-royale-geometry-aa-last-pass.cg"
+filter_linear13 = "true"
+scale_type13 = "viewport"
+mipmap_input13 = "true"
+texture_wrap_mode13 = "clamp_to_edge"
+

--- a/crt/crt-royale-ntsc-256px-svideo.cgp
+++ b/crt/crt-royale-ntsc-256px-svideo.cgp
@@ -1,0 +1,224 @@
+# IMPORTANT:
+# Shader passes need to know details about the image in the mask_texture LUT
+# files, so set the following constants in user-cgp-constants.h accordingly:
+# 1.) mask_triads_per_tile = (number of horizontal triads in mask texture LUT's)
+# 2.) mask_texture_small_size = (texture size of mask*texture_small LUT's)
+# 3.) mask_texture_large_size = (texture size of mask*texture_large LUT's)
+# 4.) mask_grille_avg_color = (avg. brightness of mask_grille_texture* LUT's, in [0, 1])
+# 5.) mask_slot_avg_color = (avg. brightness of mask_slot_texture* LUT's, in [0, 1])
+# 6.) mask_shadow_avg_color = (avg. brightness of mask_shadow_texture* LUT's, in [0, 1])
+# Shader passes also need to know certain scales set in this .cgp, but their
+# compilation model doesn't currently allow the .cgp file to tell them.  Make
+# sure to set the following constants in user-cgp-constants.h accordingly too:
+# 1.) bloom_approx_scale_x = scale_x2
+# 2.) mask_resize_viewport_scale = float2(scale_x6, scale_y5)
+# Finally, shader passes need to know the value of geom_max_aspect_ratio used to
+# calculate scale_y5 (among other values):
+# 1.) geom_max_aspect_ratio = (geom_max_aspect_ratio used to calculate scale_y5)
+
+shaders = "14"
+
+# NTSC Shader Passes
+shader0 = "../ntsc/shaders/ntsc-pass1-svideo-3phase.cg"
+shader1 = "../ntsc/shaders/ntsc-pass2-3phase.cg"
+
+filter_linear0 = false
+filter_linear1 = false
+
+scale_type_x0 = absolute
+scale_type_y0 = source
+scale_x0 = 1024
+scale_y0 = 1.0
+frame_count_mod0 = 2
+float_framebuffer0 = true
+
+scale_type1 = source
+scale_x1 = 0.5
+scale_y1 = 1.0
+
+# Set an identifier, filename, and sampling traits for the phosphor mask texture.
+# Load an aperture grille, slot mask, and an EDP shadow mask, and load a small
+# non-mipmapped version and a large mipmapped version.
+# TODO: Test masks in other directories.
+textures = "mask_grille_texture_small;mask_grille_texture_large;mask_slot_texture_small;mask_slot_texture_large;mask_shadow_texture_small;mask_shadow_texture_large"
+mask_grille_texture_small = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5SpacingResizeTo64.png"
+mask_grille_texture_large = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5Spacing.png"
+mask_slot_texture_small = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacingResizeTo64.png"
+mask_slot_texture_large = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacing.png"
+mask_shadow_texture_small = "shaders/crt-royale/TileableLinearShadowMaskEDPResizeTo64.png"
+mask_shadow_texture_large = "shaders/crt-royale/TileableLinearShadowMaskEDP.png"
+mask_grille_texture_small_wrap_mode = "repeat"
+mask_grille_texture_large_wrap_mode = "repeat"
+mask_slot_texture_small_wrap_mode = "repeat"
+mask_slot_texture_large_wrap_mode = "repeat"
+mask_shadow_texture_small_wrap_mode = "repeat"
+mask_shadow_texture_large_wrap_mode = "repeat"
+mask_grille_texture_small_linear = "true"
+mask_grille_texture_large_linear = "true"
+mask_slot_texture_small_linear = "true"
+mask_slot_texture_large_linear = "true"
+mask_shadow_texture_small_linear = "true"
+mask_shadow_texture_large_linear = "true"
+mask_grille_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_grille_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+mask_slot_texture_small_mipmap = "false"    # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_slot_texture_large_mipmap = "true"     # Essential for hardware-resized masks
+mask_shadow_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_shadow_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+
+
+# Pass2: Linearize the input based on CRT gamma and bob interlaced fields.
+# (Bobbing ensures we can immediately blur without getting artifacts.)
+shader2 = "shaders/crt-royale/src/crt-royale-first-pass-linearize-crt-gamma-bob-fields.cg"
+alias2 = "ORIG_LINEARIZED"
+filter_linear2 = "false"
+scale_type2 = "source"
+scale2 = "1.0"
+srgb_framebuffer2 = "true"
+
+# Pass3: Resample interlaced (and misconverged) scanlines vertically.
+# Separating vertical/horizontal scanline sampling is faster: It lets us
+# consider more scanlines while calculating weights for fewer pixels, and
+# it reduces our samples from vertical*horizontal to vertical+horizontal.
+# This has to come right after ORIG_LINEARIZED, because there's no
+# "original_source" scale_type we can use later.
+shader3 = "shaders/crt-royale/src/crt-royale-scanlines-vertical-interlacing.cg"
+alias3 = "VERTICAL_SCANLINES"
+filter_linear3 = "true"
+scale_type_x3 = "source"
+scale_x3 = "1.0"
+scale_type_y3 = "viewport"
+scale_y3 = "1.0"
+#float_framebuffer3 = "true"
+srgb_framebuffer3 = "true"
+
+# Pass4: Do a small resize blur of ORIG_LINEARIZED at an absolute size, and
+# account for convergence offsets.  We want to blur a predictable portion of the
+# screen to match the phosphor bloom, and absolute scale works best for
+# reliable results with a fixed-size bloom.  Picking a scale is tricky:
+# a.) 400x300 is a good compromise for the "fake-bloom" version: It's low enough
+#     to blur high-res/interlaced sources but high enough that resampling
+#     doesn't smear low-res sources too much.
+# b.) 320x240 works well for the "real bloom" version: It's 1-1.5% faster, and
+#     the only noticeable visual difference is a larger halation spread (which
+#     may be a good thing for people who like to crank it up).
+# Note the 4:3 aspect ratio assumes the input has cropped geom_overscan (so it's
+# *intended* for an ~4:3 aspect ratio).
+shader4 = "shaders/crt-royale/src/crt-royale-bloom-approx.cg"
+alias4 = "BLOOM_APPROX"
+filter_linear4 = "true"
+scale_type4 = "absolute"
+scale_x4 = "320"
+scale_y4 = "240"
+srgb_framebuffer4 = "true"
+
+# Pass5: Vertically blur the input for halation and refractive diffusion.
+# Base this on BLOOM_APPROX: This blur should be small and fast, and blurring
+# a constant portion of the screen is probably physically correct if the
+# viewport resolution is proportional to the simulated CRT size.
+shader5 = "../blurs/blur9fast-vertical.cg"
+filter_linear5 = "true"
+scale_type5 = "source"
+scale5 = "1.0"
+srgb_framebuffer5 = "true"
+
+# Pass6: Horizontally blur the input for halation and refractive diffusion.
+# Note: Using a one-pass 9x9 blur is about 1% slower.
+shader6 = "../blurs/blur9fast-horizontal.cg"
+alias6 = "HALATION_BLUR"
+filter_linear6 = "true"
+scale_type6 = "source"
+scale6 = "1.0"
+srgb_framebuffer6 = "true"
+
+# Pass7: Lanczos-resize the phosphor mask vertically.  Set the absolute
+# scale_x7 == mask_texture_small_size.x (see IMPORTANT above).  Larger scales
+# will blur, and smaller scales could get nasty.  The vertical size must be
+# based on the viewport size and calculated carefully to avoid artifacts later.
+# First calculate the minimum number of mask tiles we need to draw.
+# Since curvature is computed after the scanline masking pass:
+#   num_resized_mask_tiles = 2.0;
+# If curvature were computed in the scanline masking pass (it's not):
+#   max_mask_texel_border = ~3.0 * (1/3.0 + 4.0*sqrt(2.0) + 0.5 + 1.0);
+#   max_mask_tile_border = max_mask_texel_border/
+#       (min_resized_phosphor_triad_size * mask_triads_per_tile);
+#   num_resized_mask_tiles = max(2.0, 1.0 + max_mask_tile_border * 2.0);
+#   At typical values (triad_size >= 2.0, mask_triads_per_tile == 8):
+#       num_resized_mask_tiles = ~3.8
+# Triad sizes are given in horizontal terms, so we need geom_max_aspect_ratio
+# to relate them to vertical resolution.  The widest we expect is:
+#   geom_max_aspect_ratio = 4.0/3.0  # Note: Shader passes need to know this!
+# The fewer triads we tile across the screen, the larger each triad will be as a
+# fraction of the viewport size, and the larger scale_y5 must be to draw a full
+# num_resized_mask_tiles.  Therefore, we must decide the smallest number of
+# triads we'll guarantee can be displayed on screen.  We'll set this according
+# to 3-pixel triads at 768p resolution (the lowest anyone's likely to use):
+#   min_allowed_viewport_triads = 768.0*geom_max_aspect_ratio / 3.0 = 341.333333
+# Now calculate the viewport scale that ensures we can draw resized_mask_tiles:
+#   min_scale_x = resized_mask_tiles * mask_triads_per_tile /
+#       min_allowed_viewport_triads
+#   scale_y7 = geom_max_aspect_ratio * min_scale_x
+#   # Some code might depend on equal scales:
+#   scale_x8 = scale_y7
+# Given our default geom_max_aspect_ratio and min_allowed_viewport_triads:
+#   scale_y7 = 4.0/3.0 * 2.0/(341.33333 / 8.0) = 0.0625
+# IMPORTANT: The scales MUST be calculated in this way.  If you wish to change
+# geom_max_aspect_ratio, update that constant in user-cgp-constants.h!
+shader7 = "shaders/crt-royale/src/crt-royale-mask-resize-vertical.cg"
+filter_linear7 = "true"
+scale_type_x7 = "absolute"
+scale_x7 = "64"
+scale_type_y7 = "viewport"
+scale_y7 = "0.0625" # Safe for >= 341.333 horizontal triads at viewport size
+#srgb_framebuffer7 = "false" # mask_texture is already assumed linear
+
+# Pass8: Lanczos-resize the phosphor mask horizontally.  scale_x8 = scale_y7.
+# TODO: Check again if the shaders actually require equal scales.
+shader8 = "shaders/crt-royale/src/crt-royale-mask-resize-horizontal.cg"
+alias8 = "MASK_RESIZE"
+filter_linear8 = "false"
+scale_type_x8 = "viewport"
+scale_x8 = "0.0625"
+scale_type_y8 = "source"
+scale_y8 = "1.0"
+#srgb_framebuffer8 = "false" # mask_texture is already assumed linear
+
+# Pass9: Resample (misconverged) scanlines horizontally, apply halation, and
+# apply the phosphor mask.
+shader9 = "shaders/crt-royale/src/crt-royale-scanlines-horizontal-apply-mask.cg"
+alias9 = "MASKED_SCANLINES"
+filter_linear9 = "true" # This could just as easily be nearest neighbor.
+scale_type9 = "viewport"
+scale9 = "1.0"
+#float_framebuffer9 = "true"
+srgb_framebuffer9 = "true"
+
+# Pass 10: Compute a brightpass.  This will require reading the final mask.
+shader10 = "shaders/crt-royale/src/crt-royale-brightpass.cg"
+alias10 = "BRIGHTPASS"
+filter_linear10 = "true" # This could just as easily be nearest neighbor.
+scale_type10 = "viewport"
+scale10 = "1.0"
+srgb_framebuffer10 = "true"
+
+# Pass 11: Blur the brightpass vertically
+shader11 = "shaders/crt-royale/src/crt-royale-bloom-vertical.cg"
+filter_linear11 = "true" # This could just as easily be nearest neighbor.
+scale_type11 = "source"
+scale11 = "1.0"
+srgb_framebuffer11 = "true"
+
+# Pass 12: Blur the brightpass horizontally and combine it with the dimpass:
+shader12 = "shaders/crt-royale/src/crt-royale-bloom-horizontal-reconstitute.cg"
+filter_linear12 = "true"
+scale_type12 = "source"
+scale12 = "1.0"
+srgb_framebuffer12 = "true"
+
+# Pass 13: Compute curvature/AA:
+shader13 = "shaders/crt-royale/src/crt-royale-geometry-aa-last-pass.cg"
+filter_linear13 = "true"
+scale_type13 = "viewport"
+mipmap_input13 = "true"
+texture_wrap_mode13 = "clamp_to_edge"
+

--- a/crt/crt-royale-ntsc-320px-composite.cgp
+++ b/crt/crt-royale-ntsc-320px-composite.cgp
@@ -1,0 +1,224 @@
+# IMPORTANT:
+# Shader passes need to know details about the image in the mask_texture LUT
+# files, so set the following constants in user-cgp-constants.h accordingly:
+# 1.) mask_triads_per_tile = (number of horizontal triads in mask texture LUT's)
+# 2.) mask_texture_small_size = (texture size of mask*texture_small LUT's)
+# 3.) mask_texture_large_size = (texture size of mask*texture_large LUT's)
+# 4.) mask_grille_avg_color = (avg. brightness of mask_grille_texture* LUT's, in [0, 1])
+# 5.) mask_slot_avg_color = (avg. brightness of mask_slot_texture* LUT's, in [0, 1])
+# 6.) mask_shadow_avg_color = (avg. brightness of mask_shadow_texture* LUT's, in [0, 1])
+# Shader passes also need to know certain scales set in this .cgp, but their
+# compilation model doesn't currently allow the .cgp file to tell them.  Make
+# sure to set the following constants in user-cgp-constants.h accordingly too:
+# 1.) bloom_approx_scale_x = scale_x2
+# 2.) mask_resize_viewport_scale = float2(scale_x6, scale_y5)
+# Finally, shader passes need to know the value of geom_max_aspect_ratio used to
+# calculate scale_y5 (among other values):
+# 1.) geom_max_aspect_ratio = (geom_max_aspect_ratio used to calculate scale_y5)
+
+shaders = "14"
+
+# NTSC Shader Passes
+shader0 = "../ntsc/shaders/ntsc-pass1-composite-2phase.cg"
+shader1 = "../ntsc/shaders/ntsc-pass2-2phase.cg"
+
+filter_linear0 = false
+filter_linear1 = false
+
+scale_type_x0 = absolute 
+scale_type_y0 = source
+scale_x0 = 1280
+scale_y0 = 1.0
+frame_count_mod0 = 2
+float_framebuffer0 = true
+
+scale_type1 = source
+scale_x1 = 0.5
+scale_y1 = 1.0
+
+# Set an identifier, filename, and sampling traits for the phosphor mask texture.
+# Load an aperture grille, slot mask, and an EDP shadow mask, and load a small
+# non-mipmapped version and a large mipmapped version.
+# TODO: Test masks in other directories.
+textures = "mask_grille_texture_small;mask_grille_texture_large;mask_slot_texture_small;mask_slot_texture_large;mask_shadow_texture_small;mask_shadow_texture_large"
+mask_grille_texture_small = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5SpacingResizeTo64.png"
+mask_grille_texture_large = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5Spacing.png"
+mask_slot_texture_small = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacingResizeTo64.png"
+mask_slot_texture_large = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacing.png"
+mask_shadow_texture_small = "shaders/crt-royale/TileableLinearShadowMaskEDPResizeTo64.png"
+mask_shadow_texture_large = "shaders/crt-royale/TileableLinearShadowMaskEDP.png"
+mask_grille_texture_small_wrap_mode = "repeat"
+mask_grille_texture_large_wrap_mode = "repeat"
+mask_slot_texture_small_wrap_mode = "repeat"
+mask_slot_texture_large_wrap_mode = "repeat"
+mask_shadow_texture_small_wrap_mode = "repeat"
+mask_shadow_texture_large_wrap_mode = "repeat"
+mask_grille_texture_small_linear = "true"
+mask_grille_texture_large_linear = "true"
+mask_slot_texture_small_linear = "true"
+mask_slot_texture_large_linear = "true"
+mask_shadow_texture_small_linear = "true"
+mask_shadow_texture_large_linear = "true"
+mask_grille_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_grille_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+mask_slot_texture_small_mipmap = "false"    # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_slot_texture_large_mipmap = "true"     # Essential for hardware-resized masks
+mask_shadow_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_shadow_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+
+
+# Pass2: Linearize the input based on CRT gamma and bob interlaced fields.
+# (Bobbing ensures we can immediately blur without getting artifacts.)
+shader2 = "shaders/crt-royale/src/crt-royale-first-pass-linearize-crt-gamma-bob-fields.cg"
+alias2 = "ORIG_LINEARIZED"
+filter_linear2 = "false"
+scale_type2 = "source"
+scale2 = "1.0"
+srgb_framebuffer2 = "true"
+
+# Pass3: Resample interlaced (and misconverged) scanlines vertically.
+# Separating vertical/horizontal scanline sampling is faster: It lets us
+# consider more scanlines while calculating weights for fewer pixels, and
+# it reduces our samples from vertical*horizontal to vertical+horizontal.
+# This has to come right after ORIG_LINEARIZED, because there's no
+# "original_source" scale_type we can use later.
+shader3 = "shaders/crt-royale/src/crt-royale-scanlines-vertical-interlacing.cg"
+alias3 = "VERTICAL_SCANLINES"
+filter_linear3 = "true"
+scale_type_x3 = "source"
+scale_x3 = "1.0"
+scale_type_y3 = "viewport"
+scale_y3 = "1.0"
+#float_framebuffer3 = "true"
+srgb_framebuffer3 = "true"
+
+# Pass4: Do a small resize blur of ORIG_LINEARIZED at an absolute size, and
+# account for convergence offsets.  We want to blur a predictable portion of the
+# screen to match the phosphor bloom, and absolute scale works best for
+# reliable results with a fixed-size bloom.  Picking a scale is tricky:
+# a.) 400x300 is a good compromise for the "fake-bloom" version: It's low enough
+#     to blur high-res/interlaced sources but high enough that resampling
+#     doesn't smear low-res sources too much.
+# b.) 320x240 works well for the "real bloom" version: It's 1-1.5% faster, and
+#     the only noticeable visual difference is a larger halation spread (which
+#     may be a good thing for people who like to crank it up).
+# Note the 4:3 aspect ratio assumes the input has cropped geom_overscan (so it's
+# *intended* for an ~4:3 aspect ratio).
+shader4 = "shaders/crt-royale/src/crt-royale-bloom-approx.cg"
+alias4 = "BLOOM_APPROX"
+filter_linear4 = "true"
+scale_type4 = "absolute"
+scale_x4 = "320"
+scale_y4 = "240"
+srgb_framebuffer4 = "true"
+
+# Pass5: Vertically blur the input for halation and refractive diffusion.
+# Base this on BLOOM_APPROX: This blur should be small and fast, and blurring
+# a constant portion of the screen is probably physically correct if the
+# viewport resolution is proportional to the simulated CRT size.
+shader5 = "../blurs/blur9fast-vertical.cg"
+filter_linear5 = "true"
+scale_type5 = "source"
+scale5 = "1.0"
+srgb_framebuffer5 = "true"
+
+# Pass6: Horizontally blur the input for halation and refractive diffusion.
+# Note: Using a one-pass 9x9 blur is about 1% slower.
+shader6 = "../blurs/blur9fast-horizontal.cg"
+alias6 = "HALATION_BLUR"
+filter_linear6 = "true"
+scale_type6 = "source"
+scale6 = "1.0"
+srgb_framebuffer6 = "true"
+
+# Pass7: Lanczos-resize the phosphor mask vertically.  Set the absolute
+# scale_x7 == mask_texture_small_size.x (see IMPORTANT above).  Larger scales
+# will blur, and smaller scales could get nasty.  The vertical size must be
+# based on the viewport size and calculated carefully to avoid artifacts later.
+# First calculate the minimum number of mask tiles we need to draw.
+# Since curvature is computed after the scanline masking pass:
+#   num_resized_mask_tiles = 2.0;
+# If curvature were computed in the scanline masking pass (it's not):
+#   max_mask_texel_border = ~3.0 * (1/3.0 + 4.0*sqrt(2.0) + 0.5 + 1.0);
+#   max_mask_tile_border = max_mask_texel_border/
+#       (min_resized_phosphor_triad_size * mask_triads_per_tile);
+#   num_resized_mask_tiles = max(2.0, 1.0 + max_mask_tile_border * 2.0);
+#   At typical values (triad_size >= 2.0, mask_triads_per_tile == 8):
+#       num_resized_mask_tiles = ~3.8
+# Triad sizes are given in horizontal terms, so we need geom_max_aspect_ratio
+# to relate them to vertical resolution.  The widest we expect is:
+#   geom_max_aspect_ratio = 4.0/3.0  # Note: Shader passes need to know this!
+# The fewer triads we tile across the screen, the larger each triad will be as a
+# fraction of the viewport size, and the larger scale_y5 must be to draw a full
+# num_resized_mask_tiles.  Therefore, we must decide the smallest number of
+# triads we'll guarantee can be displayed on screen.  We'll set this according
+# to 3-pixel triads at 768p resolution (the lowest anyone's likely to use):
+#   min_allowed_viewport_triads = 768.0*geom_max_aspect_ratio / 3.0 = 341.333333
+# Now calculate the viewport scale that ensures we can draw resized_mask_tiles:
+#   min_scale_x = resized_mask_tiles * mask_triads_per_tile /
+#       min_allowed_viewport_triads
+#   scale_y7 = geom_max_aspect_ratio * min_scale_x
+#   # Some code might depend on equal scales:
+#   scale_x8 = scale_y7
+# Given our default geom_max_aspect_ratio and min_allowed_viewport_triads:
+#   scale_y7 = 4.0/3.0 * 2.0/(341.33333 / 8.0) = 0.0625
+# IMPORTANT: The scales MUST be calculated in this way.  If you wish to change
+# geom_max_aspect_ratio, update that constant in user-cgp-constants.h!
+shader7 = "shaders/crt-royale/src/crt-royale-mask-resize-vertical.cg"
+filter_linear7 = "true"
+scale_type_x7 = "absolute"
+scale_x7 = "64"
+scale_type_y7 = "viewport"
+scale_y7 = "0.0625" # Safe for >= 341.333 horizontal triads at viewport size
+#srgb_framebuffer7 = "false" # mask_texture is already assumed linear
+
+# Pass8: Lanczos-resize the phosphor mask horizontally.  scale_x8 = scale_y7.
+# TODO: Check again if the shaders actually require equal scales.
+shader8 = "shaders/crt-royale/src/crt-royale-mask-resize-horizontal.cg"
+alias8 = "MASK_RESIZE"
+filter_linear8 = "false"
+scale_type_x8 = "viewport"
+scale_x8 = "0.0625"
+scale_type_y8 = "source"
+scale_y8 = "1.0"
+#srgb_framebuffer8 = "false" # mask_texture is already assumed linear
+
+# Pass9: Resample (misconverged) scanlines horizontally, apply halation, and
+# apply the phosphor mask.
+shader9 = "shaders/crt-royale/src/crt-royale-scanlines-horizontal-apply-mask.cg"
+alias9 = "MASKED_SCANLINES"
+filter_linear9 = "true" # This could just as easily be nearest neighbor.
+scale_type9 = "viewport"
+scale9 = "1.0"
+#float_framebuffer9 = "true"
+srgb_framebuffer9 = "true"
+
+# Pass 10: Compute a brightpass.  This will require reading the final mask.
+shader10 = "shaders/crt-royale/src/crt-royale-brightpass.cg"
+alias10 = "BRIGHTPASS"
+filter_linear10 = "true" # This could just as easily be nearest neighbor.
+scale_type10 = "viewport"
+scale10 = "1.0"
+srgb_framebuffer10 = "true"
+
+# Pass 11: Blur the brightpass vertically
+shader11 = "shaders/crt-royale/src/crt-royale-bloom-vertical.cg"
+filter_linear11 = "true" # This could just as easily be nearest neighbor.
+scale_type11 = "source"
+scale11 = "1.0"
+srgb_framebuffer11 = "true"
+
+# Pass 12: Blur the brightpass horizontally and combine it with the dimpass:
+shader12 = "shaders/crt-royale/src/crt-royale-bloom-horizontal-reconstitute.cg"
+filter_linear12 = "true"
+scale_type12 = "source"
+scale12 = "1.0"
+srgb_framebuffer12 = "true"
+
+# Pass 13: Compute curvature/AA:
+shader13 = "shaders/crt-royale/src/crt-royale-geometry-aa-last-pass.cg"
+filter_linear13 = "true"
+scale_type13 = "viewport"
+mipmap_input13 = "true"
+texture_wrap_mode13 = "clamp_to_edge"
+

--- a/crt/crt-royale-ntsc-320px-svideo.cgp
+++ b/crt/crt-royale-ntsc-320px-svideo.cgp
@@ -1,0 +1,224 @@
+# IMPORTANT:
+# Shader passes need to know details about the image in the mask_texture LUT
+# files, so set the following constants in user-cgp-constants.h accordingly:
+# 1.) mask_triads_per_tile = (number of horizontal triads in mask texture LUT's)
+# 2.) mask_texture_small_size = (texture size of mask*texture_small LUT's)
+# 3.) mask_texture_large_size = (texture size of mask*texture_large LUT's)
+# 4.) mask_grille_avg_color = (avg. brightness of mask_grille_texture* LUT's, in [0, 1])
+# 5.) mask_slot_avg_color = (avg. brightness of mask_slot_texture* LUT's, in [0, 1])
+# 6.) mask_shadow_avg_color = (avg. brightness of mask_shadow_texture* LUT's, in [0, 1])
+# Shader passes also need to know certain scales set in this .cgp, but their
+# compilation model doesn't currently allow the .cgp file to tell them.  Make
+# sure to set the following constants in user-cgp-constants.h accordingly too:
+# 1.) bloom_approx_scale_x = scale_x2
+# 2.) mask_resize_viewport_scale = float2(scale_x6, scale_y5)
+# Finally, shader passes need to know the value of geom_max_aspect_ratio used to
+# calculate scale_y5 (among other values):
+# 1.) geom_max_aspect_ratio = (geom_max_aspect_ratio used to calculate scale_y5)
+
+shaders = "14"
+
+# NTSC Shader Passes
+shader0 = "../ntsc/shaders/ntsc-pass1-svideo-2phase.cg"
+shader1 = "../ntsc/shaders/ntsc-pass2-2phase.cg"
+
+filter_linear0 = false
+filter_linear1 = false
+
+scale_type_x0 = absolute 
+scale_type_y0 = source
+scale_x0 = 1280
+scale_y0 = 1.0
+frame_count_mod0 = 2
+float_framebuffer0 = true
+
+scale_type1 = source
+scale_x1 = 0.5
+scale_y1 = 1.0
+
+# Set an identifier, filename, and sampling traits for the phosphor mask texture.
+# Load an aperture grille, slot mask, and an EDP shadow mask, and load a small
+# non-mipmapped version and a large mipmapped version.
+# TODO: Test masks in other directories.
+textures = "mask_grille_texture_small;mask_grille_texture_large;mask_slot_texture_small;mask_slot_texture_large;mask_shadow_texture_small;mask_shadow_texture_large"
+mask_grille_texture_small = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5SpacingResizeTo64.png"
+mask_grille_texture_large = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5Spacing.png"
+mask_slot_texture_small = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacingResizeTo64.png"
+mask_slot_texture_large = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacing.png"
+mask_shadow_texture_small = "shaders/crt-royale/TileableLinearShadowMaskEDPResizeTo64.png"
+mask_shadow_texture_large = "shaders/crt-royale/TileableLinearShadowMaskEDP.png"
+mask_grille_texture_small_wrap_mode = "repeat"
+mask_grille_texture_large_wrap_mode = "repeat"
+mask_slot_texture_small_wrap_mode = "repeat"
+mask_slot_texture_large_wrap_mode = "repeat"
+mask_shadow_texture_small_wrap_mode = "repeat"
+mask_shadow_texture_large_wrap_mode = "repeat"
+mask_grille_texture_small_linear = "true"
+mask_grille_texture_large_linear = "true"
+mask_slot_texture_small_linear = "true"
+mask_slot_texture_large_linear = "true"
+mask_shadow_texture_small_linear = "true"
+mask_shadow_texture_large_linear = "true"
+mask_grille_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_grille_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+mask_slot_texture_small_mipmap = "false"    # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_slot_texture_large_mipmap = "true"     # Essential for hardware-resized masks
+mask_shadow_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_shadow_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+
+
+# Pass2: Linearize the input based on CRT gamma and bob interlaced fields.
+# (Bobbing ensures we can immediately blur without getting artifacts.)
+shader2 = "shaders/crt-royale/src/crt-royale-first-pass-linearize-crt-gamma-bob-fields.cg"
+alias2 = "ORIG_LINEARIZED"
+filter_linear2 = "false"
+scale_type2 = "source"
+scale2 = "1.0"
+srgb_framebuffer2 = "true"
+
+# Pass3: Resample interlaced (and misconverged) scanlines vertically.
+# Separating vertical/horizontal scanline sampling is faster: It lets us
+# consider more scanlines while calculating weights for fewer pixels, and
+# it reduces our samples from vertical*horizontal to vertical+horizontal.
+# This has to come right after ORIG_LINEARIZED, because there's no
+# "original_source" scale_type we can use later.
+shader3 = "shaders/crt-royale/src/crt-royale-scanlines-vertical-interlacing.cg"
+alias3 = "VERTICAL_SCANLINES"
+filter_linear3 = "true"
+scale_type_x3 = "source"
+scale_x3 = "1.0"
+scale_type_y3 = "viewport"
+scale_y3 = "1.0"
+#float_framebuffer3 = "true"
+srgb_framebuffer3 = "true"
+
+# Pass4: Do a small resize blur of ORIG_LINEARIZED at an absolute size, and
+# account for convergence offsets.  We want to blur a predictable portion of the
+# screen to match the phosphor bloom, and absolute scale works best for
+# reliable results with a fixed-size bloom.  Picking a scale is tricky:
+# a.) 400x300 is a good compromise for the "fake-bloom" version: It's low enough
+#     to blur high-res/interlaced sources but high enough that resampling
+#     doesn't smear low-res sources too much.
+# b.) 320x240 works well for the "real bloom" version: It's 1-1.5% faster, and
+#     the only noticeable visual difference is a larger halation spread (which
+#     may be a good thing for people who like to crank it up).
+# Note the 4:3 aspect ratio assumes the input has cropped geom_overscan (so it's
+# *intended* for an ~4:3 aspect ratio).
+shader4 = "shaders/crt-royale/src/crt-royale-bloom-approx.cg"
+alias4 = "BLOOM_APPROX"
+filter_linear4 = "true"
+scale_type4 = "absolute"
+scale_x4 = "320"
+scale_y4 = "240"
+srgb_framebuffer4 = "true"
+
+# Pass5: Vertically blur the input for halation and refractive diffusion.
+# Base this on BLOOM_APPROX: This blur should be small and fast, and blurring
+# a constant portion of the screen is probably physically correct if the
+# viewport resolution is proportional to the simulated CRT size.
+shader5 = "../blurs/blur9fast-vertical.cg"
+filter_linear5 = "true"
+scale_type5 = "source"
+scale5 = "1.0"
+srgb_framebuffer5 = "true"
+
+# Pass6: Horizontally blur the input for halation and refractive diffusion.
+# Note: Using a one-pass 9x9 blur is about 1% slower.
+shader6 = "../blurs/blur9fast-horizontal.cg"
+alias6 = "HALATION_BLUR"
+filter_linear6 = "true"
+scale_type6 = "source"
+scale6 = "1.0"
+srgb_framebuffer6 = "true"
+
+# Pass7: Lanczos-resize the phosphor mask vertically.  Set the absolute
+# scale_x7 == mask_texture_small_size.x (see IMPORTANT above).  Larger scales
+# will blur, and smaller scales could get nasty.  The vertical size must be
+# based on the viewport size and calculated carefully to avoid artifacts later.
+# First calculate the minimum number of mask tiles we need to draw.
+# Since curvature is computed after the scanline masking pass:
+#   num_resized_mask_tiles = 2.0;
+# If curvature were computed in the scanline masking pass (it's not):
+#   max_mask_texel_border = ~3.0 * (1/3.0 + 4.0*sqrt(2.0) + 0.5 + 1.0);
+#   max_mask_tile_border = max_mask_texel_border/
+#       (min_resized_phosphor_triad_size * mask_triads_per_tile);
+#   num_resized_mask_tiles = max(2.0, 1.0 + max_mask_tile_border * 2.0);
+#   At typical values (triad_size >= 2.0, mask_triads_per_tile == 8):
+#       num_resized_mask_tiles = ~3.8
+# Triad sizes are given in horizontal terms, so we need geom_max_aspect_ratio
+# to relate them to vertical resolution.  The widest we expect is:
+#   geom_max_aspect_ratio = 4.0/3.0  # Note: Shader passes need to know this!
+# The fewer triads we tile across the screen, the larger each triad will be as a
+# fraction of the viewport size, and the larger scale_y5 must be to draw a full
+# num_resized_mask_tiles.  Therefore, we must decide the smallest number of
+# triads we'll guarantee can be displayed on screen.  We'll set this according
+# to 3-pixel triads at 768p resolution (the lowest anyone's likely to use):
+#   min_allowed_viewport_triads = 768.0*geom_max_aspect_ratio / 3.0 = 341.333333
+# Now calculate the viewport scale that ensures we can draw resized_mask_tiles:
+#   min_scale_x = resized_mask_tiles * mask_triads_per_tile /
+#       min_allowed_viewport_triads
+#   scale_y7 = geom_max_aspect_ratio * min_scale_x
+#   # Some code might depend on equal scales:
+#   scale_x8 = scale_y7
+# Given our default geom_max_aspect_ratio and min_allowed_viewport_triads:
+#   scale_y7 = 4.0/3.0 * 2.0/(341.33333 / 8.0) = 0.0625
+# IMPORTANT: The scales MUST be calculated in this way.  If you wish to change
+# geom_max_aspect_ratio, update that constant in user-cgp-constants.h!
+shader7 = "shaders/crt-royale/src/crt-royale-mask-resize-vertical.cg"
+filter_linear7 = "true"
+scale_type_x7 = "absolute"
+scale_x7 = "64"
+scale_type_y7 = "viewport"
+scale_y7 = "0.0625" # Safe for >= 341.333 horizontal triads at viewport size
+#srgb_framebuffer7 = "false" # mask_texture is already assumed linear
+
+# Pass8: Lanczos-resize the phosphor mask horizontally.  scale_x8 = scale_y7.
+# TODO: Check again if the shaders actually require equal scales.
+shader8 = "shaders/crt-royale/src/crt-royale-mask-resize-horizontal.cg"
+alias8 = "MASK_RESIZE"
+filter_linear8 = "false"
+scale_type_x8 = "viewport"
+scale_x8 = "0.0625"
+scale_type_y8 = "source"
+scale_y8 = "1.0"
+#srgb_framebuffer8 = "false" # mask_texture is already assumed linear
+
+# Pass9: Resample (misconverged) scanlines horizontally, apply halation, and
+# apply the phosphor mask.
+shader9 = "shaders/crt-royale/src/crt-royale-scanlines-horizontal-apply-mask.cg"
+alias9 = "MASKED_SCANLINES"
+filter_linear9 = "true" # This could just as easily be nearest neighbor.
+scale_type9 = "viewport"
+scale9 = "1.0"
+#float_framebuffer9 = "true"
+srgb_framebuffer9 = "true"
+
+# Pass 10: Compute a brightpass.  This will require reading the final mask.
+shader10 = "shaders/crt-royale/src/crt-royale-brightpass.cg"
+alias10 = "BRIGHTPASS"
+filter_linear10 = "true" # This could just as easily be nearest neighbor.
+scale_type10 = "viewport"
+scale10 = "1.0"
+srgb_framebuffer10 = "true"
+
+# Pass 11: Blur the brightpass vertically
+shader11 = "shaders/crt-royale/src/crt-royale-bloom-vertical.cg"
+filter_linear11 = "true" # This could just as easily be nearest neighbor.
+scale_type11 = "source"
+scale11 = "1.0"
+srgb_framebuffer11 = "true"
+
+# Pass 12: Blur the brightpass horizontally and combine it with the dimpass:
+shader12 = "shaders/crt-royale/src/crt-royale-bloom-horizontal-reconstitute.cg"
+filter_linear12 = "true"
+scale_type12 = "source"
+scale12 = "1.0"
+srgb_framebuffer12 = "true"
+
+# Pass 13: Compute curvature/AA:
+shader13 = "shaders/crt-royale/src/crt-royale-geometry-aa-last-pass.cg"
+filter_linear13 = "true"
+scale_type13 = "viewport"
+mipmap_input13 = "true"
+texture_wrap_mode13 = "clamp_to_edge"
+

--- a/crt/crt-royale-tvout+image-adjustment.cgp
+++ b/crt/crt-royale-tvout+image-adjustment.cgp
@@ -1,0 +1,225 @@
+# IMPORTANT:
+# Shader passes need to know details about the image in the mask_texture LUT
+# files, so set the following constants in user-cgp-constants.h accordingly:
+# 1.) mask_triads_per_tile = (number of horizontal triads in mask texture LUT's)
+# 2.) mask_texture_small_size = (texture size of mask*texture_small LUT's)
+# 3.) mask_texture_large_size = (texture size of mask*texture_large LUT's)
+# 4.) mask_grille_avg_color = (avg. brightness of mask_grille_texture* LUT's, in [0, 1])
+# 5.) mask_slot_avg_color = (avg. brightness of mask_slot_texture* LUT's, in [0, 1])
+# 6.) mask_shadow_avg_color = (avg. brightness of mask_shadow_texture* LUT's, in [0, 1])
+# Shader passes also need to know certain scales set in this .cgp, but their
+# compilation model doesn't currently allow the .cgp file to tell them.  Make
+# sure to set the following constants in user-cgp-constants.h accordingly too:
+# 1.) bloom_approx_scale_x = scale_x2
+# 2.) mask_resize_viewport_scale = float2(scale_x6, scale_y5)
+# Finally, shader passes need to know the value of geom_max_aspect_ratio used to
+# calculate scale_y5 (among other values):
+# 1.) geom_max_aspect_ratio = (geom_max_aspect_ratio used to calculate scale_y5)
+
+shaders = "14"
+
+# tvout-tweaks and image-adjustment passes
+shader0 = "shaders/tvout-tweaks.cg"
+shader1 = "../misc/image-adjustment.cg"
+
+filter_linear0 = true
+filter_linear1 = false
+
+scale_type_x0 = "viewport"
+scale_x0 = "1.000000"
+scale_type_y0 = "source"
+scale_y0 = "1.000000"
+
+scale_type1 = "source"
+scale = "1.00000"
+
+# Set an identifier, filename, and sampling traits for the phosphor mask texture.
+# Load an aperture grille, slot mask, and an EDP shadow mask, and load a small
+# non-mipmapped version and a large mipmapped version.
+# TODO: Test masks in other directories.
+textures = "mask_grille_texture_small;mask_grille_texture_large;mask_slot_texture_small;mask_slot_texture_large;mask_shadow_texture_small;mask_shadow_texture_large"
+mask_grille_texture_small = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5SpacingResizeTo64.png"
+mask_grille_texture_large = "shaders/crt-royale/TileableLinearApertureGrille15Wide8And5d5Spacing.png"
+mask_slot_texture_small = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacingResizeTo64.png"
+mask_slot_texture_large = "shaders/crt-royale/TileableLinearSlotMaskTall15Wide9And4d5Horizontal9d14VerticalSpacing.png"
+mask_shadow_texture_small = "shaders/crt-royale/TileableLinearShadowMaskEDPResizeTo64.png"
+mask_shadow_texture_large = "shaders/crt-royale/TileableLinearShadowMaskEDP.png"
+mask_grille_texture_small_wrap_mode = "repeat"
+mask_grille_texture_large_wrap_mode = "repeat"
+mask_slot_texture_small_wrap_mode = "repeat"
+mask_slot_texture_large_wrap_mode = "repeat"
+mask_shadow_texture_small_wrap_mode = "repeat"
+mask_shadow_texture_large_wrap_mode = "repeat"
+mask_grille_texture_small_linear = "true"
+mask_grille_texture_large_linear = "true"
+mask_slot_texture_small_linear = "true"
+mask_slot_texture_large_linear = "true"
+mask_shadow_texture_small_linear = "true"
+mask_shadow_texture_large_linear = "true"
+mask_grille_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_grille_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+mask_slot_texture_small_mipmap = "false"    # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_slot_texture_large_mipmap = "true"     # Essential for hardware-resized masks
+mask_shadow_texture_small_mipmap = "false"  # Mipmapping causes artifacts with manually resized masks without tex2Dlod
+mask_shadow_texture_large_mipmap = "true"   # Essential for hardware-resized masks
+
+
+# Pass2: Linearize the input based on CRT gamma and bob interlaced fields.
+# (Bobbing ensures we can immediately blur without getting artifacts.)
+shader2 = "shaders/crt-royale/src/crt-royale-first-pass-linearize-crt-gamma-bob-fields.cg"
+alias2 = "ORIG_LINEARIZED"
+filter_linear2 = "false"
+scale_type2 = "source"
+scale2 = "1.0"
+srgb_framebuffer2 = "true"
+
+# Pass3: Resample interlaced (and misconverged) scanlines vertically.
+# Separating vertical/horizontal scanline sampling is faster: It lets us
+# consider more scanlines while calculating weights for fewer pixels, and
+# it reduces our samples from vertical*horizontal to vertical+horizontal.
+# This has to come right after ORIG_LINEARIZED, because there's no
+# "original_source" scale_type we can use later.
+shader3 = "shaders/crt-royale/src/crt-royale-scanlines-vertical-interlacing.cg"
+alias3 = "VERTICAL_SCANLINES"
+filter_linear3 = "true"
+scale_type_x3 = "source"
+scale_x3 = "1.0"
+scale_type_y3 = "viewport"
+scale_y3 = "1.0"
+#float_framebuffer3 = "true"
+srgb_framebuffer3 = "true"
+
+# Pass4: Do a small resize blur of ORIG_LINEARIZED at an absolute size, and
+# account for convergence offsets.  We want to blur a predictable portion of the
+# screen to match the phosphor bloom, and absolute scale works best for
+# reliable results with a fixed-size bloom.  Picking a scale is tricky:
+# a.) 400x300 is a good compromise for the "fake-bloom" version: It's low enough
+#     to blur high-res/interlaced sources but high enough that resampling
+#     doesn't smear low-res sources too much.
+# b.) 320x240 works well for the "real bloom" version: It's 1-1.5% faster, and
+#     the only noticeable visual difference is a larger halation spread (which
+#     may be a good thing for people who like to crank it up).
+# Note the 4:3 aspect ratio assumes the input has cropped geom_overscan (so it's
+# *intended* for an ~4:3 aspect ratio).
+shader4 = "shaders/crt-royale/src/crt-royale-bloom-approx.cg"
+alias4 = "BLOOM_APPROX"
+filter_linear4 = "true"
+scale_type4 = "absolute"
+scale_x4 = "320"
+scale_y4 = "240"
+srgb_framebuffer4 = "true"
+
+# Pass5: Vertically blur the input for halation and refractive diffusion.
+# Base this on BLOOM_APPROX: This blur should be small and fast, and blurring
+# a constant portion of the screen is probably physically correct if the
+# viewport resolution is proportional to the simulated CRT size.
+shader5 = "../blurs/blur9fast-vertical.cg"
+filter_linear5 = "true"
+scale_type5 = "source"
+scale5 = "1.0"
+srgb_framebuffer5 = "true"
+
+# Pass6: Horizontally blur the input for halation and refractive diffusion.
+# Note: Using a one-pass 9x9 blur is about 1% slower.
+shader6 = "../blurs/blur9fast-horizontal.cg"
+alias6 = "HALATION_BLUR"
+filter_linear6 = "true"
+scale_type6 = "source"
+scale6 = "1.0"
+srgb_framebuffer6 = "true"
+
+# Pass7: Lanczos-resize the phosphor mask vertically.  Set the absolute
+# scale_x7 == mask_texture_small_size.x (see IMPORTANT above).  Larger scales
+# will blur, and smaller scales could get nasty.  The vertical size must be
+# based on the viewport size and calculated carefully to avoid artifacts later.
+# First calculate the minimum number of mask tiles we need to draw.
+# Since curvature is computed after the scanline masking pass:
+#   num_resized_mask_tiles = 2.0;
+# If curvature were computed in the scanline masking pass (it's not):
+#   max_mask_texel_border = ~3.0 * (1/3.0 + 4.0*sqrt(2.0) + 0.5 + 1.0);
+#   max_mask_tile_border = max_mask_texel_border/
+#       (min_resized_phosphor_triad_size * mask_triads_per_tile);
+#   num_resized_mask_tiles = max(2.0, 1.0 + max_mask_tile_border * 2.0);
+#   At typical values (triad_size >= 2.0, mask_triads_per_tile == 8):
+#       num_resized_mask_tiles = ~3.8
+# Triad sizes are given in horizontal terms, so we need geom_max_aspect_ratio
+# to relate them to vertical resolution.  The widest we expect is:
+#   geom_max_aspect_ratio = 4.0/3.0  # Note: Shader passes need to know this!
+# The fewer triads we tile across the screen, the larger each triad will be as a
+# fraction of the viewport size, and the larger scale_y5 must be to draw a full
+# num_resized_mask_tiles.  Therefore, we must decide the smallest number of
+# triads we'll guarantee can be displayed on screen.  We'll set this according
+# to 3-pixel triads at 768p resolution (the lowest anyone's likely to use):
+#   min_allowed_viewport_triads = 768.0*geom_max_aspect_ratio / 3.0 = 341.333333
+# Now calculate the viewport scale that ensures we can draw resized_mask_tiles:
+#   min_scale_x = resized_mask_tiles * mask_triads_per_tile /
+#       min_allowed_viewport_triads
+#   scale_y7 = geom_max_aspect_ratio * min_scale_x
+#   # Some code might depend on equal scales:
+#   scale_x8 = scale_y7
+# Given our default geom_max_aspect_ratio and min_allowed_viewport_triads:
+#   scale_y7 = 4.0/3.0 * 2.0/(341.33333 / 8.0) = 0.0625
+# IMPORTANT: The scales MUST be calculated in this way.  If you wish to change
+# geom_max_aspect_ratio, update that constant in user-cgp-constants.h!
+shader7 = "shaders/crt-royale/src/crt-royale-mask-resize-vertical.cg"
+filter_linear7 = "true"
+scale_type_x7 = "absolute"
+scale_x7 = "64"
+scale_type_y7 = "viewport"
+scale_y7 = "0.0625" # Safe for >= 341.333 horizontal triads at viewport size
+#srgb_framebuffer7 = "false" # mask_texture is already assumed linear
+
+# Pass8: Lanczos-resize the phosphor mask horizontally.  scale_x8 = scale_y7.
+# TODO: Check again if the shaders actually require equal scales.
+shader8 = "shaders/crt-royale/src/crt-royale-mask-resize-horizontal.cg"
+alias8 = "MASK_RESIZE"
+filter_linear8 = "false"
+scale_type_x8 = "viewport"
+scale_x8 = "0.0625"
+scale_type_y8 = "source"
+scale_y8 = "1.0"
+#srgb_framebuffer8 = "false" # mask_texture is already assumed linear
+
+# Pass9: Resample (misconverged) scanlines horizontally, apply halation, and
+# apply the phosphor mask.
+shader9 = "shaders/crt-royale/src/crt-royale-scanlines-horizontal-apply-mask.cg"
+alias9 = "MASKED_SCANLINES"
+filter_linear9 = "true" # This could just as easily be nearest neighbor.
+scale_type9 = "viewport"
+scale9 = "1.0"
+#float_framebuffer9 = "true"
+srgb_framebuffer9 = "true"
+
+# Pass 10: Compute a brightpass.  This will require reading the final mask.
+shader10 = "shaders/crt-royale/src/crt-royale-brightpass.cg"
+alias10 = "BRIGHTPASS"
+filter_linear10 = "true" # This could just as easily be nearest neighbor.
+scale_type10 = "viewport"
+scale10 = "1.0"
+srgb_framebuffer10 = "true"
+
+# Pass 11: Blur the brightpass vertically
+shader11 = "shaders/crt-royale/src/crt-royale-bloom-vertical.cg"
+filter_linear11 = "true" # This could just as easily be nearest neighbor.
+scale_type11 = "source"
+scale11 = "1.0"
+srgb_framebuffer11 = "true"
+
+# Pass 12: Blur the brightpass horizontally and combine it with the dimpass:
+shader12 = "shaders/crt-royale/src/crt-royale-bloom-horizontal-reconstitute.cg"
+filter_linear12 = "true"
+scale_type12 = "source"
+scale12 = "1.0"
+srgb_framebuffer12 = "true"
+
+# Pass 13: Compute curvature/AA:
+shader13 = "shaders/crt-royale/src/crt-royale-geometry-aa-last-pass.cg"
+filter_linear13 = "true"
+scale_type13 = "viewport"
+mipmap_input13 = "true"
+texture_wrap_mode13 = "clamp_to_edge"
+
+parameters = "TVOUT_RESOLUTION;target_gamma"
+TVOUT_RESOLUTION = "320.000000"
+target_gamma = "2.200000"
+


### PR DESCRIPTION
Adds NTSC presets for CRT Royale. Also adds a preset with tvout-tweaks and image-adjustment as well.

These use the default CRT Royale preset (crt-royale.cgp) only for now, and I doubt Intel iGPUs will be able to run CRT Royale combined with anything anyway, especially not with the NTSC shader.