### PR TITLE
(nes-color-decoder) Use correct level when color is 0xE and 0xF

### DIFF
--- a/misc/nes-color-decoder-alt.cg
+++ b/misc/nes-color-decoder-alt.cg
@@ -62,6 +62,9 @@ float3 MakeRGBColor(int emphasis, int level, int color)
    float g = 0.0;
    float b = 0.0;
 
+   // Color 0xE and 0xF are black
+   level = (color < 14) ? level : 1;
+
    // Voltage levels, relative to synch voltage
    float black = 0.518;
    float white = 1.962;

--- a/misc/nes-color-decoder-sony.cg
+++ b/misc/nes-color-decoder-sony.cg
@@ -62,6 +62,9 @@ float3 MakeRGBColor(int emphasis, int level, int color)
    float g = 0.0;
    float b = 0.0;
 
+   // Color 0xE and 0xF are black
+   level = (color < 14) ? level : 1;
+
    // Voltage levels, relative to synch voltage
    float black = 0.518;
    float white = 1.962;

--- a/misc/nes-color-decoder.cg
+++ b/misc/nes-color-decoder.cg
@@ -62,6 +62,9 @@ float3 MakeRGBColor(int emphasis, int level, int color)
    float g = 0.0;
    float b = 0.0;
 
+   // Color 0xE and 0xF are black
+   level = (color < 14) ? level : 1;
+
    // Voltage levels, relative to synch voltage
    float black = 0.518;
    float white = 1.962;


### PR DESCRIPTION
see https://github.com/libretro/slang-shaders/pull/57