### PR TITLE
Fix/Port various shaders to HLSL/FX11

### DIFF
--- a/crt/shaders/4xbr-hybrid-crt.cg
+++ b/crt/shaders/4xbr-hybrid-crt.cg
@@ -50,6 +50,7 @@
  */
 
 #include "../../compat_includes.inc"
+
 uniform COMPAT_Texture2D(decal) : TEXUNIT0;
 uniform float4x4 modelViewProj;
 
@@ -113,7 +114,7 @@ float4 weighted_distance(float4 a, float4 b, float4 c, float4 d, float4 e, float
 
 struct out_vertex
 {
-	half4 position  : POSITION;
+	half4 position  : COMPAT_POS;
 	float2 texCoord : TEXCOORD0;
 	float4 t1       : TEXCOORD1;
 	float4 t2       : TEXCOORD2;
@@ -341,7 +342,6 @@ float4 xBR_hybrid_CRT(float2 texture_size, float2 texCoord, COMPAT_Texture2D(dec
             color *= float3( COLOR_BOOST, COLOR_BOOST, COLOR_BOOST );
 
 	return float4(clamp( GAMMA_OUT(color), 0.0, 1.0 ), 1.0);
-
 
 	return float4(res.x, res.y, res.z, 1.0);
 

--- a/crt/shaders/crt-hyllian-multipass/crt-hyllian-pass0.cg
+++ b/crt/shaders/crt-hyllian-multipass/crt-hyllian-pass0.cg
@@ -44,6 +44,11 @@ uniform float InputGamma;
 
 #define GAMMA_IN(color)     pow(color, float3(InputGamma, InputGamma, InputGamma))
 
+#include "../../../compat_includes.inc"
+
+uniform COMPAT_Texture2D(decal) : TEXUNIT0;
+uniform float4x4 modelViewProj;
+
 // Horizontal cubic filter.
 
 // Some known filters use these values:
@@ -69,59 +74,42 @@ const static float4x4 invX = float4x4(            (-B - 6.0*C)/6.0,         (3.0
                                                    (B + 6.0*C)/6.0,                           -C,                      0.0,               0.0);
 
 
-struct input
-{
-    float2 video_size;
-    float2 texture_size;
-    float2 output_size;
-    float  frame_count;
-    float  frame_direction;
-    float  frame_rotation;
-};
-
-
 struct out_vertex {
+    float4 position : COMPAT_POS;
     float2 texCoord : TEXCOORD0;
 };
 
 /*    VERTEX_SHADER    */
-out_vertex main_vertex
-(
-    float4 position      : POSITION,
-    out float4 oPosition : POSITION,
-    float2 texCoord      : TEXCOORD0,
-
-    uniform float4x4 modelViewProj,
-    uniform input IN
-)
+out_vertex main_vertex(COMPAT_IN_VERTEX)
 {
-    oPosition = mul(modelViewProj, position);
-
-    out_vertex OUT = {
-        texCoord
-    };
-
+#ifdef HLSL_4
+	float4 position = VIN.position;
+	float2 texCoord = VIN.texCoord;
+#endif
+    out_vertex OUT;
+    OUT.position = mul(modelViewProj, position);
+    OUT.texCoord = texCoord;
     return OUT;
 }
 
-
-float4 main_fragment(in out_vertex VAR, uniform sampler2D s_p : TEXUNIT0, uniform input IN) : COLOR
+float4 main_fragment(COMPAT_IN_FRAGMENT) : COMPAT_Output
 {
-    float2 TextureSize = float2(SHARPNESS*IN.texture_size.x, IN.texture_size.y);
+	float2 texCoord = VOUT.texCoord;
+    float2 TextureSize = float2(SHARPNESS*COMPAT_texture_size.x, COMPAT_texture_size.y);
 
     float3 color;
     float2 dx = float2(1.0/TextureSize.x, 0.0);
     float2 dy = float2(0.0, 1.0/TextureSize.y);
-    float2 pix_coord = VAR.texCoord*TextureSize+float2(-0.5,0.0);
+    float2 pix_coord = texCoord*TextureSize+float2(-0.5,0.0);
 
     float2 tc = (floor(pix_coord)+float2(0.5,0.0))/TextureSize;
 
     float2 fp = frac(pix_coord);
 
-    float3 c10 = GAMMA_IN(tex2D(s_p, tc     - dx).xyz);
-    float3 c11 = GAMMA_IN(tex2D(s_p, tc         ).xyz);
-    float3 c12 = GAMMA_IN(tex2D(s_p, tc     + dx).xyz);
-    float3 c13 = GAMMA_IN(tex2D(s_p, tc + 2.0*dx).xyz);
+    float3 c10 = GAMMA_IN(COMPAT_SamplePoint(decal, tc     - dx).xyz);
+    float3 c11 = GAMMA_IN(COMPAT_SamplePoint(decal, tc         ).xyz);
+    float3 c12 = GAMMA_IN(COMPAT_SamplePoint(decal, tc     + dx).xyz);
+    float3 c13 = GAMMA_IN(COMPAT_SamplePoint(decal, tc + 2.0*dx).xyz);
 
     //  Get min/max samples
     float3 min_sample = min(c11,c12);
@@ -139,4 +127,4 @@ float4 main_fragment(in out_vertex VAR, uniform sampler2D s_p : TEXUNIT0, unifor
 
     return float4(color, 1.0);
 }
-
+COMPAT_END

--- a/crt/shaders/crt-hyllian-multipass/crt-hyllian-pass1.cg
+++ b/crt/shaders/crt-hyllian-multipass/crt-hyllian-pass1.cg
@@ -62,72 +62,63 @@ uniform float BEAM_MAX_WIDTH;
 
 #define GAMMA_OUT(color)    pow(color, float3(1.0 / OutputGamma, 1.0 / OutputGamma, 1.0 / OutputGamma))
 
+#include "../../../compat_includes.inc"
 
-struct prev
-{
-   uniform float2 video_size;
-   uniform float2 texture_size;
-   uniform sampler2D texture;
-};
+uniform COMPAT_Texture2D(decal) : TEXUNIT0;
+uniform float4x4 modelViewProj;
 
-
-struct input
-{
-    float2 video_size;
-    float2 texture_size;
-    float2 output_size;
-    float  frame_count;
-    float  frame_direction;
-    float  frame_rotation;
-};
-
+prev PASSPREV1;
 
 struct out_vertex {
+    float4 position : COMPAT_POS;
     float2 texCoord : TEXCOORD0;
 };
 
 /*    VERTEX_SHADER    */
-out_vertex main_vertex
-(
-    float4 position      : POSITION,
-    out float4 oPosition : POSITION,
-    float2 texCoord      : TEXCOORD0,
-
-    uniform float4x4 modelViewProj,
-    uniform input IN
-)
+out_vertex main_vertex(COMPAT_IN_VERTEX)
 {
-    oPosition = mul(modelViewProj, position);
-
-    out_vertex OUT = {
-        texCoord
-    };
-
+#ifdef HLSL_4
+	float4 position = VIN.position;
+	float2 texCoord = VIN.texCoord;
+#endif
+    out_vertex OUT;
+    OUT.position = mul(modelViewProj, position);
+    OUT.texCoord = texCoord;
     return OUT;
 }
 
-
-float4 main_fragment(in out_vertex VAR, uniform sampler2D s_p : TEXUNIT0, prev PASSPREV1, uniform input IN) : COLOR
+float4 main_fragment(COMPAT_IN_FRAGMENT) : COMPAT_Output
 {
-    float2 TextureSize = float2(PASSPREV1.texture_size.x, IN.texture_size.y);
+	float2 texCoord = VOUT.texCoord;
+#ifdef HLSL_4
+    float2 COMPAT_PASSPREV1_texture_size = texture_size;
+    float2 COMPAT_PASSPREV1_video_size = video_size;
+#else
+    float2 COMPAT_PASSPREV1_texture_size = PASSPREV1.texture_size;
+    float2 COMPAT_PASSPREV1_video_size = PASSPREV1.video_size;
+#endif
+
+    float2 TextureSize = float2(COMPAT_PASSPREV1_texture_size.x, COMPAT_texture_size.y);
 
     float3 color;
     float2 dx = float2(1.0/TextureSize.x, 0.0);
     float2 dy = float2(0.0, 1.0/TextureSize.y);
-    float2 pix_coord = VAR.texCoord*TextureSize+float2(0.0,0.5);
+    float2 pix_coord = texCoord*TextureSize+float2(0.0,0.5);
 
     float2 tc = (floor(pix_coord)+float2(0.0,0.5))/TextureSize;
 
     float2 fp = frac(pix_coord);
 
-    float3 color0 = tex2D(s_p, tc - dy).xyz;
-    float3 color1 = tex2D(s_p, tc     ).xyz;
+    float3 color0 = COMPAT_SamplePoint(decal, tc - dy).xyz;
+    float3 color1 = COMPAT_SamplePoint(decal, tc     ).xyz;
 
     float pos0 = fp.y;
     float pos1 = 1 - fp.y;
 
-    float3 lum0 = lerp(float3(BEAM_MIN_WIDTH), float3(BEAM_MAX_WIDTH), color0);
-    float3 lum1 = lerp(float3(BEAM_MIN_WIDTH), float3(BEAM_MAX_WIDTH), color1);
+    float3 beam_min = float3(BEAM_MIN_WIDTH, BEAM_MIN_WIDTH, BEAM_MIN_WIDTH);
+    float3 beam_max = float3(BEAM_MAX_WIDTH, BEAM_MAX_WIDTH, BEAM_MAX_WIDTH);
+    float3 lum0 = lerp(beam_min, beam_max, color0);
+    float3 lum1 = lerp(beam_min, beam_max, color1);
 
     float3 d0 = clamp(pos0/(lum0+0.0000001), 0.0, 1.0);
     float3 d1 = clamp(pos1/(lum1+0.0000001), 0.0, 1.0);
@@ -138,7 +129,7 @@ float4 main_fragment(in out_vertex VAR, uniform sampler2D s_p : TEXUNIT0, prev P
     color = clamp(color0*d0+color1*d1, 0.0, 1.0);            
 
     color *= COLOR_BOOST*float3(RED_BOOST, GREEN_BOOST, BLUE_BOOST);
-    float mod_factor = VAR.texCoord.x * IN.output_size.x * PASSPREV1.texture_size.x / PASSPREV1.video_size.x;
+    float mod_factor = texCoord.x * COMPAT_output_size.x * COMPAT_PASSPREV1_texture_size.x / COMPAT_PASSPREV1_video_size.x;
 
     float3 dotMaskWeights = lerp(
                                  float3(1.0, 0.7, 1.0),
@@ -152,4 +143,4 @@ float4 main_fragment(in out_vertex VAR, uniform sampler2D s_p : TEXUNIT0, prev P
 
     return float4(color, 1.0);
 }
-
+COMPAT_END

--- a/crt/shaders/phosphor.cg
+++ b/crt/shaders/phosphor.cg
@@ -77,7 +77,7 @@ float3 to_focus(float pixel)
       return float3(1.0 - pixel, pixel, 0.0);
 }
 
-float4 phosphor(float2 coord, float2 coord_prev, float2 coord_prev_prev, float2 tex_index, COMPAT_Texture2D(decal))
+float4 phosphor(float2 coord, float2 coord_prev, float2 coord_prev_prev, float2 tex_index)
 {
    float y = fmod(tex_index.y, 1.0);
    float intensity = exp(-0.2 * y);
@@ -104,11 +104,9 @@ float4 phosphor(float2 coord, float2 coord_prev, float2 coord_prev_prev, float2 
    return float4(clamp( GAMMA_OUT(intensity * result), 0.0, 1.0 ), 1.0);
 }
 
-uniform COMPAT_Texture2D(samp) : TEXUNIT0;
-
 float4 main_fragment(COMPAT_IN_FRAGMENT) : COMPAT_Output
 {
-	return phosphor(VOUT.coord, VOUT.coord_prev, VOUT.coord_prev_prev, VOUT.tex_index, samp);
+	return phosphor(VOUT.coord, VOUT.coord_prev, VOUT.coord_prev_prev, VOUT.tex_index);
 }
 
 COMPAT_END

--- a/include/compat_macros.inc
+++ b/include/compat_macros.inc
@@ -55,15 +55,4 @@
 	#else
 		#define COMPAT_END
 	#endif
-	
-	#define COMPAT_DEFAULT_VS_SHADER \
-		out_vertex main_vertex(out_vertex VIN) \
-		{ \
-		  COMPAT_START_SHADER_DEFAULT \
-		  out_vertex OUT; \
-		  OUT.position = mul(modelViewProj, position); \
-		  OUT.texCoord = texCoord * 1.0004; \
-		  return OUT; \
-		}
-		
 #endif // COMPAT_MACROS

--- a/misc/image-adjustment.cg
+++ b/misc/image-adjustment.cg
@@ -68,57 +68,51 @@ uniform float GRAIN_STR;
    - Cg   compilers
 */
 
-struct input
+#include "../compat_includes.inc"
+
+uniform COMPAT_Texture2D(decal) : TEXUNIT0;
+uniform float4x4 modelViewProj;
+
+struct out_vertex
 {
-  float2 video_size;
-  float2 texture_size;
-  float2 output_size;
-  float  frame_count;
-  float  frame_direction;
-  float frame_rotation;
+	float4 position : COMPAT_POS;
+	float2 texCoord : TEXCOORD;
+	float2 tex_border : TEXCOORD1;
 };
 
-void main_vertex
-(
-    float4 position    : POSITION,
-    float4 color    : COLOR,
-    float2 texCoord : TEXCOORD0,
 
-    uniform float4x4 modelViewProj,
-    uniform input IN,
-
-    out float4 oPosition : POSITION,
-    out float4 oColor    : COLOR,
-    out float2 otexCoord : TEXCOORD
-)
+out_vertex main_vertex(COMPAT_IN_VERTEX)
 {
-   oPosition = mul(modelViewProj, position);
-   oColor = color;
-   float2 shift = 0.5 * IN.video_size / IN.texture_size;
+#ifdef HLSL_4
+   float4 position = VIN.position;
+   float2 texCoord = VIN.texCoord;
+#endif
+   out_vertex OUT;
+    
+   OUT.position = mul(modelViewProj, position);
+   float2 shift = 0.5 * COMPAT_video_size / COMPAT_texture_size;
    float2 overscan_coord = ((texCoord - shift) / ZOOM) * (1.0 - float2(overscan_percent_x / 100.0, overscan_percent_y / 100.0)) + shift;
-   otexCoord = overscan_coord + float2(XPOS, YPOS);
+   OUT.texCoord = overscan_coord + float2(XPOS, YPOS);
+   return OUT;
 }
-
-struct output 
-{
-   float4 color    : COLOR;
-};
 
 //https://www.shadertoy.com/view/4sXSWs strength= 16.0
 float3 filmGrain(float2 uv, float strength, float frameCount ){       
     float x = (uv.x + 4.0 ) * (uv.y + 4.0 ) * ((fmod(frameCount, 800.0) + 10.0) * 10.0);
-	return  float3(fmod((mod(x, 13.0) + 1.0) * (fmod(x, 123.0) + 1.0), 0.01)-0.005) * strength;
+    float v = fmod((mod(x, 13.0) + 1.0) * (fmod(x, 123.0) + 1.0), 0.01)-0.005;
+	return  float3(v, v, v) * strength;
 }
 
 float3 grayscale(float3 col)
 {
    // ATSC grayscale standard
-   return float3(dot(col, float3(0.2126, 0.7152, 0.0722)));
+   float b = dot(col, float3(0.2126, 0.7152, 0.0722));
+   return float3(b, b, b);
 }
 
 float3 rgb2hsv(float3 c)
 {
-    float4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
+    float4 K = float4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);
     float4 p = c.g < c.b ? float4(c.bg, K.wz) : float4(c.gb, K.xy);
     float4 q = c.r < p.x ? float4(p.xyw, c.r) : float4(c.r, p.yzx);
 
@@ -134,13 +128,16 @@ float3 hsv2rgb(float3 c)
     return c.z * lerp(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
 }
 
-float4 main_fragment(float2 texCoord : TEXCOORD, in sampler2D s0 : TEXUNIT0, uniform input IN) : COLOR
+float4 main_fragment(COMPAT_IN_FRAGMENT) : COMPAT_Output
 {
-   float3 film_grain = filmGrain(texCoord.xy, GRAIN_STR, IN.frame_count);
-   float2 fragcoord = texCoord.xy * (IN.texture_size.xy / IN.video_size.xy);
-   float3 res = tex2D(s0, texCoord).rgb; // sample the texture
+   float2 texCoord = VOUT.texCoord;
+
+   float3 film_grain = filmGrain(texCoord.xy, GRAIN_STR, COMPAT_frame_count);
+   float2 fragcoord = texCoord.xy * (COMPAT_texture_size.xy / COMPAT_video_size.xy);
+   float3 res = COMPAT_SamplePoint(decal, texCoord).rgb; // sample the texture
    res += film_grain;
-   float3 gamma = float3(monitor_gamma / target_gamma); // setup ratio of display's gamma vs desired gamma
+   float gamma_ratio = monitor_gamma / target_gamma;
+   float3 gamma = float3(gamma_ratio, gamma_ratio, gamma_ratio); // setup ratio of display's gamma vs desired gamma
 
 //saturation and luminance
    float3 satColor = clamp(hsv2rgb(rgb2hsv(res) * float3(1.0, saturation, luminance)), 0.0, 1.0);
@@ -148,8 +145,9 @@ float4 main_fragment(float2 texCoord : TEXCOORD, in sampler2D s0 : TEXUNIT0, uni
 //contrast and brightness
    float3 conColor = clamp((satColor - 0.5) * contrast + 0.5 + bright_boost, 0.0, 1.0);
 
-   conColor -= float3(black_level); // apply black level
-   conColor *= (1.0 / float3(1.0-black_level));
+   conColor -= float3(black_level, black_level, black_level); // apply black level
+   float min_black = 1.0-black_level;
+   conColor *= (1.0 / float3(min_black, min_black, min_black));
    conColor = pow(conColor, 1.0 / float3(gamma)); // Apply gamma correction
    conColor *= float3(R, G, B);
    if (fragcoord.y > TOPMASK && fragcoord.y < (1.0 - BOTMASK))
@@ -163,3 +161,4 @@ float4 main_fragment(float2 texCoord : TEXCOORD, in sampler2D s0 : TEXUNIT0, uni
       conColor = 0.0;
    return float4(conColor, 1.0);
 }
+COMPAT_END

--- a/ntsc/shaders/ntsc-stock.cg
+++ b/ntsc/shaders/ntsc-stock.cg
@@ -27,13 +27,13 @@ out_vertex main_vertex(COMPAT_IN_VERTEX)
 	return OUT;
 }
 
-float4 stock(float2 tex, COMPAT_Texture2D(s0))
+float4 stock(float2 tex)
 {
-   return tex2D(s0, tex);
+   return COMPAT_Sample(decal, tex);
 }
 
 float4 main_fragment(COMPAT_IN_FRAGMENT) : COMPAT_Output
 {
-	return stock(VOUT.texCoord, decal);
+	return stock(VOUT.texCoord);
 }
 COMPAT_END

--- a/retro/shaders/retro-v2.cg
+++ b/retro/shaders/retro-v2.cg
@@ -16,48 +16,39 @@
    You should have received a copy of the GNU General Public License
    along with this program; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
-
 */
 
+#include "../../compat_includes.inc"
+
+uniform COMPAT_Texture2D(decal) : TEXUNIT0;
+uniform float4x4 modelViewProj;
+
+struct out_vertex
+{
+	float4 position : COMPAT_POS;
+	float2 texCoord : TEXCOORD;
+	float2 t1 : TEXCOORD1;
+};
 /*
 	VERTEX_SHADER
 */
-void main_vertex
-(
-	float4 position	: POSITION,
-	float4 color	: COLOR,
-	float2 texCoord : TEXCOORD0,
-
-	uniform float4x4 modelViewProj,
-
-	out float4 oPosition	: POSITION,
-	out float4 oColor	: COLOR,
-	out float2 otexCoord	: TEXCOORD
-)
+out_vertex main_vertex(COMPAT_IN_VERTEX)
 {
-	oPosition = mul(modelViewProj, position);
-	oColor = color;
-	otexCoord = texCoord;
+#ifdef HLSL_4
+	float4 position = VIN.position;
+	float2 texCoord = VIN.texCoord;
+	float2 t1 = VIN.t1;
+#endif
+	out_vertex OUT;
+    OUT.position = mul(modelViewProj, position);
+    OUT.texCoord = texCoord;
+    OUT.t1 = t1;
+    return OUT;
 }
 
 /*
 	FRAGMENT SHADER
 */
-
-
-
-struct output
-{
-	float4 color	: COLOR;
-};
-
-struct input
-{
-	float2 video_size;
-	float2 texture_size;
-	float2 output_size;
-};
-
 // This value must be between 0.0 (totally black) and 1.0 (nearest neighbor)
 #pragma parameter RETRO_PIXEL_SIZE "Retro Pixel Size" 0.84 0.0 1.0 0.01
 
@@ -67,22 +58,25 @@ uniform float RETRO_PIXEL_SIZE;
 #define RETRO_PIXEL_SIZE  0.84
 #endif
 
-output main_fragment(float2 texCoord: TEXCOORD0, uniform sampler2D decal : TEXUNIT0, uniform input IN)
+float4 main_fragment(COMPAT_IN_FRAGMENT) : COMPAT_Output
 {
+	float2 texCoord = VOUT.texCoord;
+
     // Reading the texel
-    float3 E = pow(tex2D(decal, texCoord).xyz, float3(2.4));
+    float power = 2.4;
+    float3 E = pow(COMPAT_SamplePoint(decal, texCoord).xyz, float3(power, power, power));
 
-    float2 fp = frac(texCoord*IN.texture_size);
-    float2 ps = IN.video_size/IN.output_size;
+    float2 fp = frac(texCoord*COMPAT_texture_size);
+    float2 ps = COMPAT_video_size/COMPAT_output_size;
 
-    float2 f = clamp(clamp(fp + 0.5*ps, 0.0, 1.0) - RETRO_PIXEL_SIZE, 0.0, ps)/ps;
+    float2 f = clamp(clamp(fp + 0.5*ps, 0.0, 1.0) - float2(RETRO_PIXEL_SIZE, RETRO_PIXEL_SIZE), 0.0, ps)/ps;
 
     float max_coord = max(f.x, f.y);
 
     float3 res = lerp(E*(1.04+fp.x*fp.y), E*0.36, max_coord);
 
     // Product interpolation
-    output OUT;
-    OUT.color = float4(clamp( pow(res, float3(1.0 / 2.2)), 0.0, 1.0 ), 1.0);
-    return OUT;
+    float pwr = 1.0 / 2.2;
+    return float4(clamp( pow(res, float3(pwr, pwr, pwr)), 0.0, 1.0 ), 1.0);
 }
+COMPAT_END


### PR DESCRIPTION
Also remove `COMPAT_DEFAULT_VS_SHADER`.
All of these were tested on RetroArch (Cg) and RetroPlayer (HLSL/FX11).