### PR TITLE
console-border: Add some alternative presets for Game Boy systems

### DIFF
--- a/handheld/console-border/gb-dmg-alt-2x.cgp
+++ b/handheld/console-border/gb-dmg-alt-2x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/dmg-palette-0.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/dmg-bg.png
+BACKGROUND_linear = true
+BORDER = resources/dmg-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "2.0"
+SCALE = "1.0"
+OUT_X = "1600.0"
+OUT_Y = "800.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-dmg-alt-3x.cgp
+++ b/handheld/console-border/gb-dmg-alt-3x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/dmg-palette-0.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/dmg-bg.png
+BACKGROUND_linear = true
+BORDER = resources/dmg-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "3.0"
+SCALE = "1.0"
+OUT_X = "2400.0"
+OUT_Y = "1200.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-dmg-alt-4x.cgp
+++ b/handheld/console-border/gb-dmg-alt-4x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/dmg-palette-0.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/dmg-bg.png
+BACKGROUND_linear = true
+BORDER = resources/dmg-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "4.0"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-dmg-alt-5x.cgp
+++ b/handheld/console-border/gb-dmg-alt-5x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/dmg-palette-0.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/dmg-bg.png
+BACKGROUND_linear = true
+BORDER = resources/dmg-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "5.0"
+SCALE = "1.0"
+OUT_X = "4000.0"
+OUT_Y = "2000.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-dmg-alt-6x.cgp
+++ b/handheld/console-border/gb-dmg-alt-6x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/dmg-palette-0.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/dmg-bg.png
+BACKGROUND_linear = true
+BORDER = resources/dmg-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "6.0"
+SCALE = "1.0"
+OUT_X = "4800.0"
+OUT_Y = "2400.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-dmg-alt-7x.cgp
+++ b/handheld/console-border/gb-dmg-alt-7x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/dmg-palette-0.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/dmg-bg.png
+BACKGROUND_linear = true
+BORDER = resources/dmg-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "7.0"
+SCALE = "1.0"
+OUT_X = "5600.0"
+OUT_Y = "2800.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-light-alt-2x.cgp
+++ b/handheld/console-border/gb-light-alt-2x.cgp
@@ -1,0 +1,49 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gblight-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;screen_light;grey_balance;response_time"
+video_scale = "2.0"
+SCALE = "1.0"
+OUT_X = "1600.0"
+OUT_Y = "800.0"
+screen_light = "1.4"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-light-alt-3x.cgp
+++ b/handheld/console-border/gb-light-alt-3x.cgp
@@ -1,0 +1,49 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gblight-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;screen_light;grey_balance;response_time"
+video_scale = "3.0"
+SCALE = "1.0"
+OUT_X = "2400.0"
+OUT_Y = "1200.0"
+screen_light = "1.4"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-light-alt-4x.cgp
+++ b/handheld/console-border/gb-light-alt-4x.cgp
@@ -1,0 +1,49 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gblight-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;screen_light;grey_balance;response_time"
+video_scale = "4.0"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"
+screen_light = "1.4"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-light-alt-5x.cgp
+++ b/handheld/console-border/gb-light-alt-5x.cgp
@@ -1,0 +1,49 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gblight-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;screen_light;grey_balance;response_time"
+video_scale = "5.0"
+SCALE = "1.0"
+OUT_X = "4000.0"
+OUT_Y = "2000.0"
+screen_light = "1.4"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-light-alt-6x.cgp
+++ b/handheld/console-border/gb-light-alt-6x.cgp
@@ -1,0 +1,49 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gblight-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;screen_light;grey_balance;response_time"
+video_scale = "6.0"
+SCALE = "1.0"
+OUT_X = "4800.0"
+OUT_Y = "2400.0"
+screen_light = "1.4"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-light-alt-7x.cgp
+++ b/handheld/console-border/gb-light-alt-7x.cgp
@@ -1,0 +1,49 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gblight-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;screen_light;grey_balance;response_time"
+video_scale = "7.0"
+SCALE = "1.0"
+OUT_X = "5600.0"
+OUT_Y = "2800.0"
+screen_light = "1.4"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-pocket-alt-2x.cgp
+++ b/handheld/console-border/gb-pocket-alt-2x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "2.0"
+SCALE = "1.0"
+OUT_X = "1600.0"
+OUT_Y = "800.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-pocket-alt-3x.cgp
+++ b/handheld/console-border/gb-pocket-alt-3x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "3.0"
+SCALE = "1.0"
+OUT_X = "2400.0"
+OUT_Y = "1200.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-pocket-alt-4x.cgp
+++ b/handheld/console-border/gb-pocket-alt-4x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "4.0"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-pocket-alt-5x.cgp
+++ b/handheld/console-border/gb-pocket-alt-5x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "5.0"
+SCALE = "1.0"
+OUT_X = "4000.0"
+OUT_Y = "2000.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-pocket-alt-6x.cgp
+++ b/handheld/console-border/gb-pocket-alt-6x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "6.0"
+SCALE = "1.0"
+OUT_X = "4800.0"
+OUT_Y = "2400.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gb-pocket-alt-7x.cgp
+++ b/handheld/console-border/gb-pocket-alt-7x.cgp
@@ -1,0 +1,48 @@
+shaders = 6
+shader0 = shader-files/gb-pass-0.cg
+shader1 = ../shaders/gameboy/shader-files/gb-pass-1.cg
+shader2 = ../shaders/gameboy/shader-files/gb-pass-2.cg
+shader3 = ../shaders/gameboy/shader-files/gb-pass-3.cg
+shader4 = ../shaders/gameboy/shader-files/gb-pass-4.cg
+shader5 = shader-files/gb-pass-5.cg
+
+scale_type0 = viewport
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 1
+
+scale_type3 = source
+scale3 = 1
+
+scale_type4 = source
+scale4 = 1
+
+scale_type5 = source
+scale5 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = false
+filter_linear4 = false
+filter_linear5 = true
+
+textures = COLOR_PALETTE;BACKGROUND;BORDER
+COLOR_PALETTE = ../shaders/gameboy/resources/sample-palettes/gbp-palette.png
+COLOR_PALETTE_linear = false
+BACKGROUND = ../shaders/gameboy/resources/sample-bgs/paper-bg.png
+BACKGROUND_linear = true
+BORDER = resources/pocket-border-square-4x.png
+BORDER_linear = true
+
+parameters = "video_scale;SCALE;OUT_X;OUT_Y;grey_balance;response_time"
+video_scale = "7.0"
+SCALE = "1.0"
+OUT_X = "5600.0"
+OUT_Y = "2800.0"
+grey_balance = 3.0
+response_time = 0.444

--- a/handheld/console-border/gba-lcd-grid-v2-2x.cgp
+++ b/handheld/console-border/gba-lcd-grid-v2-2x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gba-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 2
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "1600.0"
+OUT_Y = "800.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "1.000000"

--- a/handheld/console-border/gba-lcd-grid-v2-3x.cgp
+++ b/handheld/console-border/gba-lcd-grid-v2-3x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gba-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 3
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "2400.0"
+OUT_Y = "1200.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "1.000000"

--- a/handheld/console-border/gba-lcd-grid-v2-4x.cgp
+++ b/handheld/console-border/gba-lcd-grid-v2-4x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gba-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 4
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "1.000000"

--- a/handheld/console-border/gba-lcd-grid-v2-5x.cgp
+++ b/handheld/console-border/gba-lcd-grid-v2-5x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gba-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 5
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "4000.0"
+OUT_Y = "2000.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "1.000000"

--- a/handheld/console-border/gba-lcd-grid-v2-6x.cgp
+++ b/handheld/console-border/gba-lcd-grid-v2-6x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gba-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 6
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "4800.0"
+OUT_Y = "2400.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "1.000000"

--- a/handheld/console-border/gba-retro-v2-2x.cgp
+++ b/handheld/console-border/gba-retro-v2-2x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gba-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 2
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "1600.0"
+OUT_Y = "800.0"
+RETRO_PIXEL_SIZE = "0.55"

--- a/handheld/console-border/gba-retro-v2-3x.cgp
+++ b/handheld/console-border/gba-retro-v2-3x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gba-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 3
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "2400.0"
+OUT_Y = "1200.0"
+RETRO_PIXEL_SIZE = "0.70"

--- a/handheld/console-border/gba-retro-v2-4x.cgp
+++ b/handheld/console-border/gba-retro-v2-4x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gba-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 4
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"
+RETRO_PIXEL_SIZE = "0.75"

--- a/handheld/console-border/gba-retro-v2-5x.cgp
+++ b/handheld/console-border/gba-retro-v2-5x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gba-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 5
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "4000.0"
+OUT_Y = "2000.0"
+RETRO_PIXEL_SIZE = "0.80"

--- a/handheld/console-border/gba-retro-v2-6x.cgp
+++ b/handheld/console-border/gba-retro-v2-6x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gba-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 6
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/gba-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "4800.0"
+OUT_Y = "2400.0"
+RETRO_PIXEL_SIZE = "0.84"

--- a/handheld/console-border/gbc-lcd-grid-v2-2x.cgp
+++ b/handheld/console-border/gbc-lcd-grid-v2-2x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gbc-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 2
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "1600.0"
+OUT_Y = "800.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "0.000000"

--- a/handheld/console-border/gbc-lcd-grid-v2-3x.cgp
+++ b/handheld/console-border/gbc-lcd-grid-v2-3x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gbc-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 3
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "2400.0"
+OUT_Y = "1200.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "0.000000"

--- a/handheld/console-border/gbc-lcd-grid-v2-4x.cgp
+++ b/handheld/console-border/gbc-lcd-grid-v2-4x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gbc-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 4
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "0.000000"

--- a/handheld/console-border/gbc-lcd-grid-v2-5x.cgp
+++ b/handheld/console-border/gbc-lcd-grid-v2-5x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gbc-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 5
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "4000.0"
+OUT_Y = "2000.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "0.000000"

--- a/handheld/console-border/gbc-lcd-grid-v2-6x.cgp
+++ b/handheld/console-border/gbc-lcd-grid-v2-6x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gbc-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 6
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "4800.0"
+OUT_Y = "2400.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "0.000000"

--- a/handheld/console-border/gbc-lcd-grid-v2-7x.cgp
+++ b/handheld/console-border/gbc-lcd-grid-v2-7x.cgp
@@ -1,0 +1,43 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/lcd_cgwg/lcd-grid-v2-nvidia.cg
+shader2 = ../shaders/color/gbc-color.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 7
+
+scale_type2 = source
+scale2 = 1
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RSUBPIX_R;RSUBPIX_G;RSUBPIX_B;GSUBPIX_R;GSUBPIX_G;GSUBPIX_B;BSUBPIX_R;BSUBPIX_G;BSUBPIX_B;gain;gamma;blacklevel;ambient;BGR"
+SCALE = "1.0"
+OUT_X = "5600.0"
+OUT_Y = "2800.0"
+RSUBPIX_R = "0.750000"
+RSUBPIX_G = "0.000000"
+RSUBPIX_B = "0.000000"
+GSUBPIX_R = "0.000000"
+GSUBPIX_G = "0.750000"
+GSUBPIX_B = "0.000000"
+BSUBPIX_R = "0.000000"
+BSUBPIX_G = "0.000000"
+BSUBPIX_B = "0.750000"
+gain = "1.500000"
+gamma = "2.200000"
+blacklevel = "0.000000"
+ambient = "0.000000"
+BGR = "0.000000"

--- a/handheld/console-border/gbc-retro-v2-2x.cgp
+++ b/handheld/console-border/gbc-retro-v2-2x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gbc-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 2
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "1600.0"
+OUT_Y = "800.0"
+RETRO_PIXEL_SIZE = "0.55"

--- a/handheld/console-border/gbc-retro-v2-3x.cgp
+++ b/handheld/console-border/gbc-retro-v2-3x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gbc-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 3
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "2400.0"
+OUT_Y = "1200.0"
+RETRO_PIXEL_SIZE = "0.7"

--- a/handheld/console-border/gbc-retro-v2-4x.cgp
+++ b/handheld/console-border/gbc-retro-v2-4x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gbc-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 4
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "3200.0"
+OUT_Y = "1600.0"
+RETRO_PIXEL_SIZE = "0.75"

--- a/handheld/console-border/gbc-retro-v2-5x.cgp
+++ b/handheld/console-border/gbc-retro-v2-5x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gbc-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 5
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "4000.0"
+OUT_Y = "2000.0"
+RETRO_PIXEL_SIZE = "0.80"

--- a/handheld/console-border/gbc-retro-v2-6x.cgp
+++ b/handheld/console-border/gbc-retro-v2-6x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gbc-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 6
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "4800.0"
+OUT_Y = "2400.0"
+RETRO_PIXEL_SIZE = "0.84"

--- a/handheld/console-border/gbc-retro-v2-7x.cgp
+++ b/handheld/console-border/gbc-retro-v2-7x.cgp
@@ -1,0 +1,30 @@
+shaders = 4
+shader0 = ../../motionblur/shaders/response-time.cg
+shader1 = ../shaders/color/gbc-color.cg
+shader2 = ../../retro/shaders/retro-v2.cg
+shader3 = shader-files/gb-pass-5.cg
+
+scale_type0 = source
+scale0 = 1
+
+scale_type1 = source
+scale1 = 1
+
+scale_type2 = source
+scale2 = 7
+
+filter_linear0 = false
+filter_linear1 = false
+filter_linear2 = false
+filter_linear3 = true
+
+textures = BORDER
+
+BORDER = resources/color-border-square-4x.png
+BORDER_linear = true
+
+parameters = "SCALE;OUT_X;OUT_Y;RETRO_PIXEL_SIZE"
+SCALE = "1.0"
+OUT_X = "5600.0"
+OUT_Y = "2800.0"
+RETRO_PIXEL_SIZE = "0.84"


### PR DESCRIPTION
The DMG, Pocket, and Light alt presets use Harlequin's original Game Boy shader, except for the pass0 shader due to the video scale parameter needed. These are scaled directly to the screen resolution, no resizing with bilinear is done by default.

The GBC and GBA presets use cgwg's lcd-grid-v2 shader with the LCD response-time shader and the appropriate color shader. Also included retro-v2 variants, if one wants just wants the grid-lines.

Note: I used lcd-grid-v2-nvidia here because it looked better, if it doesn't work on a particular GPU then remove the "-nvidia" from the filename of that pass, or use the original lcd-grid instead.