### PR TITLE
replace invalid scale_type_<number> with scale_type<number>

### DIFF
--- a/anti-aliasing/aa-shader-4.o-level2.cgp
+++ b/anti-aliasing/aa-shader-4.o-level2.cgp
@@ -12,4 +12,4 @@ scale1 = 2.0
 
 shader2 = ../sharpen/shaders/adaptive-sharpen.cg
 filter_linear2 = false
-scale_type_2 = source
+scale_type2 = source

--- a/anti-aliasing/aa-shader-4.o.cgp
+++ b/anti-aliasing/aa-shader-4.o.cgp
@@ -7,4 +7,4 @@ scale0 = 1.0
 
 shader1 = ../sharpen/shaders/adaptive-sharpen.cg
 filter_linear1 = false
-scale_type_1 = source
+scale_type1 = source

--- a/anti-aliasing/advanced-aa.cgp
+++ b/anti-aliasing/advanced-aa.cgp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/anti-aliasing/fx-aa.cgp
+++ b/anti-aliasing/fx-aa.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/fx-aa.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/anti-aliasing/fxaa-edge-detect.cgp
+++ b/anti-aliasing/fxaa-edge-detect.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/fxaa-edge-detect.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/anti-aliasing/reverse-aa.cgp
+++ b/anti-aliasing/reverse-aa.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/reverse-aa.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/bicubic/bicubic-fast.cgp
+++ b/bicubic/bicubic-fast.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/bicubic-fast.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/bicubic/bicubic-normal.cgp
+++ b/bicubic/bicubic-normal.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/bicubic-normal.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/bicubic/bicubic-sharp.cgp
+++ b/bicubic/bicubic-sharp.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/bicubic-sharp.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/bicubic/bicubic-sharper.cgp
+++ b/bicubic/bicubic-sharper.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/bicubic-sharper.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/cgp/tvout+interlacing/gtu-famicom-240p+interlacing.cgp
+++ b/cgp/tvout+interlacing/gtu-famicom-240p+interlacing.cgp
@@ -10,14 +10,14 @@ filter_linear0 = false
 frame_count_mod0 = 2
 
 shader1 = ../../crt/shaders/GTU-famicom/lowPass.cg
-scale_type_1 = source
+scale_type1 = source
 scale_1 = 1.0
 float_framebuffer1 = true
 filter_linear1 = false
 frame_count_mod1 = 32
 
 shader2 = ../../crt/shaders/GTU-famicom/combFilter.cg
-scale_type_2 = source
+scale_type2 = source
 scale_2 = 1.0
 float_framebuffer2 = true
 filter_linear2 = false

--- a/cgp/tvout/gtu-famicom-240p.cgp
+++ b/cgp/tvout/gtu-famicom-240p.cgp
@@ -10,14 +10,14 @@ filter_linear0 = false
 frame_count_mod0 = 2
 
 shader1 = ../../crt/shaders/GTU-famicom/lowPass.cg
-scale_type_1 = source
+scale_type1 = source
 scale_1 = 1.0
 float_framebuffer1 = true
 filter_linear1 = false
 frame_count_mod1 = 32
 
 shader2 = ../../crt/shaders/GTU-famicom/combFilter.cg
-scale_type_2 = source
+scale_type2 = source
 scale_2 = 1.0
 float_framebuffer2 = true
 filter_linear2 = false

--- a/crt/4xbr-hybrid-crt-b.cgp
+++ b/crt/4xbr-hybrid-crt-b.cgp
@@ -8,4 +8,4 @@ scale_y0 = 4.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/crt/4xbr-hybrid-crt.cgp
+++ b/crt/4xbr-hybrid-crt.cgp
@@ -8,4 +8,4 @@ scale_y0 = 4.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/crt/GTU-famicom-radeon.cgp
+++ b/crt/GTU-famicom-radeon.cgp
@@ -16,14 +16,14 @@ nestable_mipmap = false
 nestable_wrap_mode = clamp_to_border
 
 shader1 = shaders/GTU-famicom/lowPass_lite.cg
-scale_type_1 = source
+scale_type1 = source
 scale_1 = 1.0
 float_framebuffer1 = true
 filter_linear1 = false
 frame_count_mod1 = 32
 
 shader2 = shaders/GTU-famicom/combFilter_lite.cg
-scale_type_2 = source
+scale_type2 = source
 scale_2 = 1.0
 float_framebuffer2 = true
 filter_linear2 = false

--- a/crt/GTU-famicom.cgp
+++ b/crt/GTU-famicom.cgp
@@ -10,14 +10,14 @@ filter_linear0 = false
 frame_count_mod0 = 2
 
 shader1 = shaders/GTU-famicom/lowPass.cg
-scale_type_1 = source
+scale_type1 = source
 scale_1 = 1.0
 float_framebuffer1 = true
 filter_linear1 = false
 frame_count_mod1 = 32
 
 shader2 = shaders/GTU-famicom/combFilter.cg
-scale_type_2 = source
+scale_type2 = source
 scale_2 = 1.0
 float_framebuffer2 = true
 filter_linear2 = false

--- a/crt/crt-aperture.cgp
+++ b/crt/crt-aperture.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-aperture.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-caligari.cgp
+++ b/crt/crt-caligari.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-caligari.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-cgwg-fast.cgp
+++ b/crt/crt-cgwg-fast.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-cgwg-fast.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-easymode.cgp
+++ b/crt/crt-easymode.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-easymode.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-geom.cgp
+++ b/crt/crt-geom.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-geom.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-hyllian-3d.cgp
+++ b/crt/crt-hyllian-3d.cgp
@@ -3,4 +3,4 @@ shaders = 1
 shader0 = shaders/crt-hyllian-3d.cg
 filter_linear0 = true
 srgb_framebuffer0 = true
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-hyllian-fast.cgp
+++ b/crt/crt-hyllian-fast.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-hyllian-fast.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-hyllian-multipass.cgp
+++ b/crt/crt-hyllian-multipass.cgp
@@ -11,4 +11,4 @@ scale_y0 = 1.0
 shader1 = shaders/crt-hyllian-multipass/crt-hyllian-pass1.cg
 filter_linear1 = false
 srgb_framebuffer1 = false
-scale_type_1 = source
+scale_type1 = source

--- a/crt/crt-hyllian.cgp
+++ b/crt/crt-hyllian.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-hyllian.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-lottes-fast.cgp
+++ b/crt/crt-lottes-fast.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-lottes-fast.cg
 filter_linear0 = true
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-lottes-halation.cgp
+++ b/crt/crt-lottes-halation.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-lottes.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-lottes.cgp
+++ b/crt/crt-lottes.cgp
@@ -2,6 +2,6 @@ shaders = 1
 
 shader0 = shaders/crt-lottes.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 parameters = "bloomAmount"
 bloomAmount = "0.000000"

--- a/crt/crt-nes-mini.cgp
+++ b/crt/crt-nes-mini.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-nes-mini.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/crt-reverse-aa.cgp
+++ b/crt/crt-reverse-aa.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/crt-reverse-aa.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/dotmask.cgp
+++ b/crt/dotmask.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/dotmask.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/phosphor-trails.cgp
+++ b/crt/phosphor-trails.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/phosphor-trails.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/shaders/phosphor.cgp
+++ b/crt/shaders/phosphor.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = phosphor.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/snes-hires-blend.cgp
+++ b/crt/snes-hires-blend.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/snes-hires-blend.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/tv-highcontrast-hd-1152x672.cgp
+++ b/crt/tv-highcontrast-hd-1152x672.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/tv-highcontrast-hd-1152x672.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/tv-highcontrast-hd.cgp
+++ b/crt/tv-highcontrast-hd.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/tv-highcontrast-hd.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/crt/tvout-tweaks.cgp
+++ b/crt/tvout-tweaks.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/tvout-tweaks.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/ddt/ddt-extended.cgp
+++ b/ddt/ddt-extended.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/ddt-extended.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/ddt/ddt-sharp.cgp
+++ b/ddt/ddt-sharp.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/ddt-sharp.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/ddt/ddt-waterpaint.cgp
+++ b/ddt/ddt-waterpaint.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/ddt-waterpaint.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/ddt/ddt.cgp
+++ b/ddt/ddt.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/ddt.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/denoisers/fast-bilateral.cgp
+++ b/denoisers/fast-bilateral.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/fast-bilateral.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/dithering/gendither.cgp
+++ b/dithering/gendither.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/gendither.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/eagle/super-eagle.cgp
+++ b/eagle/super-eagle.cgp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/handheld/gbc-color.cgp
+++ b/handheld/gbc-color.cgp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/gbc-color.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/handheld/gbc-gambatte-color.cgp
+++ b/handheld/gbc-gambatte-color.cgp
@@ -2,5 +2,5 @@ shaders = 1
 
 shader0 = shaders/color/gbc-gambatte-color.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 scale0 = 1.0

--- a/motionblur/braid-rewind.cgp
+++ b/motionblur/braid-rewind.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/braid-rewind.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/motionblur/motionblur-blue.cgp
+++ b/motionblur/motionblur-blue.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/motionblur-blue.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/motionblur/motionblur-color.cgp
+++ b/motionblur/motionblur-color.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/motionblur-color.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/motionblur/motionblur-simple.cgp
+++ b/motionblur/motionblur-simple.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/motionblur-simple.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/motionblur/response-time.cgp
+++ b/motionblur/response-time.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/response-time.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/bloom.cgp
+++ b/mudlord/bloom.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/bloom.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/blur.cgp
+++ b/mudlord/blur.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/blur.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/emboss.cgp
+++ b/mudlord/emboss.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/emboss.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/mud-mudlord.cgp
+++ b/mudlord/mud-mudlord.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/mud-mudlord.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/noise-mudlord.cgp
+++ b/mudlord/noise-mudlord.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/noise-mudlord.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/oldtv.cgp
+++ b/mudlord/oldtv.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/oldtv.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/sharpen.cgp
+++ b/mudlord/sharpen.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/sharpen.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/toon.cgp
+++ b/mudlord/toon.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/toon.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/mudlord/waterpaint-mudlord.cgp
+++ b/mudlord/waterpaint-mudlord.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/waterpaint-mudlord.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/nedi/fast-bilateral-nedi.cgp
+++ b/nedi/fast-bilateral-nedi.cgp
@@ -1,7 +1,7 @@
 shaders = "5"
 shader0 = ../denoisers/shaders/fast-bilateral.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 shader1 = "shaders/nedi-pass0.cg"
 filter_linear1 = false
 wrap_mode1 = "clamp_to_border"

--- a/neon/neon-variation-1.cgp
+++ b/neon/neon-variation-1.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/neon-variation-1.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/quad/biquad.cgp
+++ b/quad/biquad.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/biquad.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/quad/quad_interp.cgp
+++ b/quad/quad_interp.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/quad_interp.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/retro/5xbr-retro.cgp
+++ b/retro/5xbr-retro.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/5xbr-retro.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/retro/aann.cgp
+++ b/retro/aann.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/aann.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/retro/bead.cgp
+++ b/retro/bead.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/bead.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/retro/bevel.cgp
+++ b/retro/bevel.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/bevel.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/retro/pixellate.cgp
+++ b/retro/pixellate.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/pixellate.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/retro/quilez.cgp
+++ b/retro/quilez.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/quilez.cg
 filter_linear0 = true
-scale_type_0 = source
+scale_type0 = source

--- a/retro/retro-v2.cgp
+++ b/retro/retro-v2.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/retro-v2.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/retro/sharp-bilinear.cgp
+++ b/retro/sharp-bilinear.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/sharp-bilinear.cg
 filter_linear0 = true
-scale_type_0 = source
+scale_type0 = source

--- a/retro/smootheststep.cgp
+++ b/retro/smootheststep.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/smootheststep.cg
 filter_linear0 = true
-scale_type_0 = source
+scale_type0 = source

--- a/retro/smoothstep.cgp
+++ b/retro/smoothstep.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/smoothstep.cg
 filter_linear0 = true
-scale_type_0 = source
+scale_type0 = source

--- a/sabr/sabr-v1.1.cgp
+++ b/sabr/sabr-v1.1.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/sabr-v1.1.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/sabr/sabr-v3.0.cgp
+++ b/sabr/sabr-v3.0.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/sabr-v3.0.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/scalehq/2xScaleHQ.cgp
+++ b/scalehq/2xScaleHQ.cgp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalehq/4xScaleHQ.cgp
+++ b/scalehq/4xScaleHQ.cgp
@@ -8,4 +8,4 @@ scale_y0 = 4.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalenx/scale2x.cgp
+++ b/scalenx/scale2x.cgp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalenx/scale2xSFX.cgp
+++ b/scalenx/scale2xSFX.cgp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalenx/scale2xplus.cgp
+++ b/scalenx/scale2xplus.cgp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalenx/scale3x.cgp
+++ b/scalenx/scale3x.cgp
@@ -8,4 +8,4 @@ scale_y0 = 3.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/scalenx/scale3xSFX.cgp
+++ b/scalenx/scale3xSFX.cgp
@@ -8,4 +8,4 @@ scale_y0 = 3.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/sharpen/adaptive-sharpen-multipass.cgp
+++ b/sharpen/adaptive-sharpen-multipass.cgp
@@ -2,7 +2,7 @@ shaders = 2
 
 shader0 = shaders/adaptive-sharpen-pass1.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source
 shader1 = shaders/adaptive-sharpen-pass2.cg
 filter_linear1 = false
-scale_type_1 = source
+scale_type1 = source

--- a/sharpen/adaptive-sharpen.cgp
+++ b/sharpen/adaptive-sharpen.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/adaptive-sharpen.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/waterpaint/water.cgp
+++ b/waterpaint/water.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/water.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/waterpaint/waterpaint-hc.cgp
+++ b/waterpaint/waterpaint-hc.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/waterpaint-hc.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/waterpaint/waterpaint.cgp
+++ b/waterpaint/waterpaint.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/waterpaint.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/jinc2-sharp.cgp
+++ b/windowed/jinc2-sharp.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/jinc2-sharp.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/jinc2-sharper-3d.cgp
+++ b/windowed/jinc2-sharper-3d.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/jinc2-sharper-3d.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/jinc2-sharper.cgp
+++ b/windowed/jinc2-sharper.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/jinc2-sharper.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/jinc2.cgp
+++ b/windowed/jinc2.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/jinc2.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/lanczos12.cgp
+++ b/windowed/lanczos12.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/lanczos12.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/lanczos16.cgp
+++ b/windowed/lanczos16.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/lanczos16.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/lanczos2-sharp-3d.cgp
+++ b/windowed/lanczos2-sharp-3d.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/lanczos2-sharp-3d.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/lanczos2-sharp.cgp
+++ b/windowed/lanczos2-sharp.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/lanczos2-sharp.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/lanczos4.cgp
+++ b/windowed/lanczos4.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/lanczos4.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/windowed/lanczos6.cgp
+++ b/windowed/lanczos6.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/lanczos6.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv1-noblend.cgp
+++ b/xbr/xbr-lv1-noblend.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv1-noblend.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv2-3d.cgp
+++ b/xbr/xbr-lv2-3d.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv2-3d.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv2-fast.cgp
+++ b/xbr/xbr-lv2-fast.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv2-fast.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv2-noblend.cgp
+++ b/xbr/xbr-lv2-noblend.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv2-noblend.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv2-small-details.cgp
+++ b/xbr/xbr-lv2-small-details.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv2-small-details.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv2.cgp
+++ b/xbr/xbr-lv2.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv2.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv3-noblend.cgp
+++ b/xbr/xbr-lv3-noblend.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv3-noblend.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xbr/xbr-lv3.cgp
+++ b/xbr/xbr-lv3.cgp
@@ -2,4 +2,4 @@ shaders = 1
 
 shader0 = shaders/xbr-lv3.cg
 filter_linear0 = false
-scale_type_0 = source
+scale_type0 = source

--- a/xsai/super-2xsai.cgp
+++ b/xsai/super-2xsai.cgp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/xsal/2xsal.cgp
+++ b/xsal/2xsal.cgp
@@ -8,4 +8,4 @@ scale_y0 = 2.0
 
 shader1 = ../stock.cg
 filter_linear1 = true
-scale_type_1 = source
+scale_type1 = source

--- a/xsoft/4xsoft.cgp
+++ b/xsoft/4xsoft.cgp
@@ -14,4 +14,4 @@ scale_y1 = 2.0
 
 shader2 = ../stock.cg
 filter_linear2 = true
-scale_type_2 = source
+scale_type2 = source

--- a/xsoft/4xsoftSdB.cgp
+++ b/xsoft/4xsoftSdB.cgp
@@ -14,4 +14,4 @@ scale_y1 = 2.0
 
 shader2 = ../stock.cg
 filter_linear2 = true
-scale_type_2 = source
+scale_type2 = source


### PR DESCRIPTION
RetroArch does not parse `scale_type_<number>` but only `scale_type<number>`.
 
Fixing the presets has no further effect though, because they all try to use scale_type `source` when `source` is the default anyways.